### PR TITLE
fix to anchorScroll with new hashbang urls

### DIFF
--- a/admin/client/js/controllers/pagedialog.js
+++ b/admin/client/js/controllers/pagedialog.js
@@ -20,7 +20,7 @@ angular.module('slatwalladmin').controller('pageDialog', [
 		//get url param to retrieve collection listing
 		$scope.pageDialogs = dialogService.getPageDialogs();
 		$scope.scrollToTopOfDialog = function(){
-			$location.hash('topOfPageDialog');
+			$location.hash('/#topOfPageDialog');
 			$anchorScroll();
 		};
 	


### PR DESCRIPTION
applying new url for hash navigation when hashbang routing is used