### PR TITLE
Removed variable displaying boolean value in HibachiListingDisplay

### DIFF
--- a/org/Hibachi/HibachiTags/HibachiListingDisplay.cfm
+++ b/org/Hibachi/HibachiTags/HibachiListingDisplay.cfm
@@ -395,7 +395,6 @@
 										</ul>
 									</div>
 								<cfelse>
-									#thisTag.expandable#|#attributes.multiselectPropertyIdentifier#
 									&nbsp;
 								</cfif>
 							</th>


### PR DESCRIPTION
Removed the boolean being displayed.  There didn't seem to be a need to display true/false to end user. This was not in Master either.