### PR TITLE
Exclude the current uncommitted order payment from the total by payment method

### DIFF
--- a/model/entity/Order.cfc
+++ b/model/entity/Order.cfc
@@ -585,7 +585,7 @@ component displayname="Order" entityname="SlatwallOrder" table="SwOrder" persist
 		
 		for(var orderPayment in getOrderPayments()) {
 			if(orderPayment.getPaymentMethod().getPaymentMethodId() eq arguments.paymentMethod.getPaymentMethodId()){
-				if(orderPayment.getStatusCode() eq "opstActive" && !orderPayment.hasErrors()) {
+				if(orderPayment.getStatusCode() eq "opstActive" && !orderPayment.hasErrors() && !orderPayment.getNewFlag()) {
 					if(orderPayment.getOrderPaymentType().getSystemCode() eq 'optCharge') {
 						totalPayments = precisionEvaluate(totalPayments + orderPayment.getAmount());	
 					} else {


### PR DESCRIPTION
Small update to exclude the current uncommitted order payment from the total by payment method.