### PR TITLE
Pointed path to custom/config/model directory

### DIFF
--- a/config/configORM.cfm
+++ b/config/configORM.cfm
@@ -1,5 +1,5 @@
 <cfset arrayAppend(this.ormsettings.cfclocation, "/Slatwall/integrationServices") />
-<cfset arrayAppend(this.ormsettings.cfclocation, "/Slatwall/custom/model/entity") />
+<cfset arrayAppend(this.ormsettings.cfclocation, "/Slatwall/custom/model") />
 <cftry>
 	<cfdbinfo datasource="#this.datasource.name#" username="#this.datasource.username#" password="#this.datasource.password#" type="Version" name="dbVersion">
 	<cfcatch>


### PR DESCRIPTION
This was an issue I ran into while working on a separate task.  custom/config/model/entity does not exist in the file system