### PR TITLE
Hotfix exchange order duplicate smartlists

### DIFF
--- a/admin/views/entity/ordertabs/addsku.cfm
+++ b/admin/views/entity/ordertabs/addsku.cfm
@@ -52,8 +52,10 @@ Notes:
 <cfparam name="rc.edit" type="boolean" />
 <cfparam name="rc.addSkuAddStockType" type="string" />
 
+<cfset local.getAddOrderItemSkuOptionsSmartList = rc.order.getAddOrderItemSkuOptionsSmartList() />
+
 <cfoutput>
-	<hb:HibachiListingDisplay smartList="#rc.order.getAddOrderItemSkuOptionsSmartList()#"
+	<hb:HibachiListingDisplay smartList="#local.getAddOrderItemSkuOptionsSmartList#"
 							  recordProcessAction="admin:entity.processOrder"
 							  recordProcessQueryString="orderItemTypeSystemCode=#rc.addSkuAddStockType#"
 							  recordProcessContext="addOrderItem"

--- a/admin/views/entity/ordertabs/addstock.cfm
+++ b/admin/views/entity/ordertabs/addstock.cfm
@@ -52,13 +52,15 @@ Notes:
 <cfparam name="rc.edit" type="boolean" />
 <cfparam name="rc.addSkuAddStockType" type="string" />
 
+<cfset local.getAddOrderItemStockOptionsSmartList = rc.order.getAddOrderItemStockOptionsSmartList() />
+
 <!--- Setup default stock location filter--->
 <cfif !isnull(rc.order.getDefaultStockLocation())>
-	<cfset rc.order.getAddOrderItemStockOptionsSmartList().addFilter("location.locationName", "#rc.order.getDefaultStockLocation().getLocationName()#")>
+	<cfset local.getAddOrderItemStockOptionsSmartList().addFilter("location.locationName", "#rc.order.getDefaultStockLocation().getLocationName()#")>
 </cfif>
 
 <cfoutput>
-	<hb:HibachiListingDisplay smartList="#rc.order.getAddOrderItemStockOptionsSmartList()#"
+	<hb:HibachiListingDisplay smartList="#local.getAddOrderItemStockOptionsSmartList#"
 							  recordProcessAction="admin:entity.processOrder"
 							  recordProcessQueryString="orderItemTypeSystemCode=#rc.addSkuAddStockType#"
 							  recordProcessContext="addOrderItem"

--- a/admin/views/entity/ordertabs/returnorderitems.cfm
+++ b/admin/views/entity/ordertabs/returnorderitems.cfm
@@ -72,8 +72,8 @@ Notes:
 		<cfset rc.addSkuAddStockType = "oitReturn" />
 		
 		<hb:HibachiTabGroup tabLocation="top">
-			<hb:HibachiTab view="admin:entity/ordertabs/addsku" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.sku')#" />
-			<hb:HibachiTab view="admin:entity/ordertabs/addstock" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.stock')#" />
+			<hb:HibachiTab tabid="roiaddsku" view="admin:entity/ordertabs/addsku" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.sku')#" />
+			<hb:HibachiTab tabid="roiaddstock" view="admin:entity/ordertabs/addstock" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.stock')#" />
 		</hb:HibachiTabGroup>
 	</cfif>
 </cfoutput>

--- a/admin/views/entity/ordertabs/saleorderitems.cfm
+++ b/admin/views/entity/ordertabs/saleorderitems.cfm
@@ -73,8 +73,8 @@ Notes:
 		
 		<hb:HibachiTabGroup tabLocation="top">
 			<cfif !isnull(rc.order.getDefaultStockLocation())>
-				<hb:HibachiTab tabid="soiaddsku" view="admin:entity/ordertabs/addstock" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.stock')#" />	
-				<hb:HibachiTab tabid="soiaddstock" view="admin:entity/ordertabs/addsku" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.sku')#" />
+				<hb:HibachiTab tabid="soiaddstock" view="admin:entity/ordertabs/addstock" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.stock')#" />	
+				<hb:HibachiTab tabid="soiaddsku" view="admin:entity/ordertabs/addsku" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.sku')#" />
 			<cfelse>
 				<hb:HibachiTab tabid="soiaddsku" view="admin:entity/ordertabs/addsku" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.sku')#" />
 				<hb:HibachiTab tabid="soiaddstock" view="admin:entity/ordertabs/addstock" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.stock')#" />	

--- a/admin/views/entity/ordertabs/saleorderitems.cfm
+++ b/admin/views/entity/ordertabs/saleorderitems.cfm
@@ -73,11 +73,11 @@ Notes:
 		
 		<hb:HibachiTabGroup tabLocation="top">
 			<cfif !isnull(rc.order.getDefaultStockLocation())>
-				<hb:HibachiTab view="admin:entity/ordertabs/addstock" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.stock')#" />	
-				<hb:HibachiTab view="admin:entity/ordertabs/addsku" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.sku')#" />
+				<hb:HibachiTab tabid="soiaddsku" view="admin:entity/ordertabs/addstock" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.stock')#" />	
+				<hb:HibachiTab tabid="soiaddstock" view="admin:entity/ordertabs/addsku" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.sku')#" />
 			<cfelse>
-				<hb:HibachiTab view="admin:entity/ordertabs/addsku" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.sku')#" />
-				<hb:HibachiTab view="admin:entity/ordertabs/addstock" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.stock')#" />	
+				<hb:HibachiTab tabid="soiaddsku" view="admin:entity/ordertabs/addsku" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.sku')#" />
+				<hb:HibachiTab tabid="soiaddstock" view="admin:entity/ordertabs/addstock" text="#$.slatwall.rbKey('define.add')# #$.slatwall.rbKey('entity.stock')#" />	
 			</cfif>
 			
 		</hb:HibachiTabGroup>


### PR DESCRIPTION
Allow for multiple occurrences of getAddOrderItemSkuOptionsSmartList & getAddOrderItemStockOptionsSmartList for sales order items and return orders items
Also fix for Add SKU and Add Stock for sales order items and return orders items