### PR TITLE
If paywall content is set to display=no, redirect to 404 page instead of...

### DIFF
--- a/integrationServices/mura/model/handler/MuraEventHandler.cfc
+++ b/integrationServices/mura/model/handler/MuraEventHandler.cfc
@@ -369,10 +369,18 @@
 				$.slatwall.setContent( barrierPage );
 				
 				// Update the mura content to use the barrier page or 404
-				if(!isNull(barrierPage.getCMSContentID()) && len(barrierPage.getCMSContentID())) {
-					$.event('contentBean', $.getBean("content").loadBy( contentID=barrierPage.getCMSContentID() ) );
+				if( !$.content('display') ) {
+
+					$.redirect( $.getBean('content').loadBy(urlTitle='404').getURL(complete=true) );
+
 				} else {
-					$.event('contentBean', $.getBean("content") );
+
+					if(!isNull(barrierPage.getCMSContentID()) && len(barrierPage.getCMSContentID())) {
+						$.event('contentBean', $.getBean("content").loadBy( contentID=barrierPage.getCMSContentID() ) );
+					} else {
+						$.event('contentBean', $.getBean("content") );
+					}
+
 				}
 			}
 		}


### PR DESCRIPTION
If paywall content is set to display=no, redirect to 404 page instead of displaying content or barrier page

Reported by Scientific American