### PR TITLE
Feature rm product bundle querystringlength

### DIFF
--- a/admin/client/js/services/slatwallInterceptor.js
+++ b/admin/client/js/services/slatwallInterceptor.js
@@ -11,6 +11,21 @@ angular.module('slatwalladmin')
 	){
 		var interceptor = {
 			'request':function(config){
+				if(config.method == 'GET' && config.url.indexOf('.html') == -1){
+					config.method = 'POST';
+					config.data = {};
+					var data = {};
+					if(angular.isDefined(config.params)){
+						data = config.params;
+					}
+					data.context = 'GET';
+					var params = {};
+					params.serializedJsonData = angular.toJson(data);
+					config.data = $.param(params);
+					delete config.params;
+					config.headers['Content-Type']= 'application/x-www-form-urlencoded';
+				}
+				
 				return config;
 			},
 			'response':function(response){
@@ -41,7 +56,7 @@ angular.module('slatwalladmin')
 				}
 				
 				return $q.reject(rejection);
-			},
+			}
 		};
 		return interceptor;
 	}

--- a/admin/client/js/services/slatwallInterceptor.js
+++ b/admin/client/js/services/slatwallInterceptor.js
@@ -18,9 +18,9 @@ angular.module('slatwalladmin')
 					if(angular.isDefined(config.params)){
 						data = config.params;
 					}
-					data.context = 'GET';
 					var params = {};
 					params.serializedJsonData = angular.toJson(data);
+					params.context="GET";
 					config.data = $.param(params);
 					delete config.params;
 					config.headers['Content-Type']= 'application/x-www-form-urlencoded';

--- a/api/controllers/main.cfc
+++ b/api/controllers/main.cfc
@@ -36,7 +36,7 @@ component output="false" accessors="true" extends="Slatwall.org.Hibachi.HibachiC
 		if(isnull(arguments.rc.apiResponse.content)){
 			arguments.rc.apiResponse.content = {};
 		}
-		if(structKEyExists(arguments.rc, 'serializedJSONData') && isSimpleValue(arguments.rc.serializedJSONData) && isJSON(arguments.rc.serializedJSONData)) {
+		if(!isNull(arguments.rc.context) && arguments.rc.context == 'GET' && structKEyExists(arguments.rc, 'serializedJSONData') && isSimpleValue(arguments.rc.serializedJSONData) && isJSON(arguments.rc.serializedJSONData)) {
 			StructAppend(arguments.rc,deserializeJSON(arguments.rc.serializedJSONData));
 		}
 	}

--- a/api/controllers/main.cfc
+++ b/api/controllers/main.cfc
@@ -36,6 +36,9 @@ component output="false" accessors="true" extends="Slatwall.org.Hibachi.HibachiC
 		if(isnull(arguments.rc.apiResponse.content)){
 			arguments.rc.apiResponse.content = {};
 		}
+		if(structKEyExists(arguments.rc, 'serializedJSONData') && isSimpleValue(arguments.rc.serializedJSONData) && isJSON(arguments.rc.serializedJSONData)) {
+			StructAppend(arguments.rc,deserializeJSON(arguments.rc.serializedJSONData));
+		}
 	}
 	
 	public any function getValidationPropertyStatus(required struct rc){


### PR DESCRIPTION
dealing with query strings that are too long.
using the client side interceptor to detect if the request is a GET and not for a partial
then converting it to a POST method using the serializedJsonData parameter with a context of GET