### PR TITLE
fix for attribute codes prefixed with numbers

### DIFF
--- a/api/views/js/ngslatwall.cfm
+++ b/api/views/js/ngslatwall.cfm
@@ -1340,8 +1340,8 @@ Notes:
 									<!---loop over possible attributes --->
 									<cfif len($.slatwall.getService('attributeService').getAttributeCodesListByAttributeSetObject(local.entity.getClassName()))>
 										<cfloop list="#$.slatwall.getService('attributeService').getAttributeCodesListByAttributeSetObject(local.entity.getClassName())#" index="local.attributeCode">
-											this.data.#local.attributeCode# = null;
-											this.metaData.#local.attributeCode# = {
+											this.data['#local.attributeCode#'] = null;
+											this.metaData['#local.attributeCode#'] = {
 												name:'#local.attributeCode#'
 											};
 										</cfloop>


### PR DESCRIPTION
data.12details is not valid javascript but data['12details'] is.