### PR TITLE
Added new parameter to the processOrder_duplicateOrder that if set to

### DIFF
--- a/model/service/OrderService.cfc
+++ b/model/service/OrderService.cfc
@@ -119,7 +119,8 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		
 		var data = {
 				saveNewFlag=true,
-				copyPersonalDataFlag=false
+				copyPersonalDataFlag=false,
+				referenceOrderFlag=false
 			};
 			
 		var newOrder = this.processOrder(arguments.originalOrder,data,"duplicateOrder" );
@@ -906,6 +907,7 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 	public any function processOrder_duplicateOrder (required any order, struct data={}) {
 		var saveNewFlag = false;
 		var copyPersonalDataFlag = false;
+		var referenceOrderFlag = true;
 		
 		if (structKeyExists(data,'saveNewFlag')){
 			saveNewFlag = data.saveNewFlag ;
@@ -914,12 +916,19 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		if (structKeyExists(data,'copyPersonalDataFlag')){
 			copyPersonalDataFlag = data.copyPersonalDataFlag ;
 		}
+		
+		if (structKeyExists(data,'referenceOrderFlag')){
+			referenceOrderFlag = data.referenceOrderFlag ;
+		}
 
 		var newOrder = this.newOrder(); 
 		
 		newOrder.setCurrencyCode( arguments.order.getCurrencyCode() );
-		newOrder.setReferencedOrder(arguments.order);
-		newOrder.setReferencedOrderType('duplicate');
+		
+		if (referenceOrderFlag == true){
+			newOrder.setReferencedOrder(arguments.order);
+			newOrder.setReferencedOrderType('duplicate');
+		}
 		
 		//Copy Order Attribtes
 		for(var attributeValue in arguments.order.getAttributeValues()) {


### PR DESCRIPTION
false does not set the referenceOrder or the referenceType. Update the
duplicateOrderWithNewAccount function to include this paramater which
will prevent the reference data being set on the front end.