### PR TITLE
Expand path just seem to work different on different environments, but a...

### DIFF
--- a/integrationServices/mura/model/handler/MuraEventHandler.cfc
+++ b/integrationServices/mura/model/handler/MuraEventHandler.cfc
@@ -769,11 +769,11 @@
 				if(getMuraPluginConfig().getSetting("createDefaultPages") && !listFindNoCase(populatedSiteIDs, cmsSiteID)) {
 					
 					// Copy views over to the template directory
-					var slatwallTemplatePath = getDirectoryFromPath(expandPath("/Slatwall/public/views/templates")); 
-					var muraTemplatesPath = getDirectoryFromPath(expandPath("/muraWRM/#cmsSiteID#/includes/themes/#cmsThemeName#/"));
+					var slatwallTemplatePath = getDirectoryFromPath(expandPath("/Slatwall") & "/public/views/templates"); 
+					var muraTemplatesPath = getDirectoryFromPath(expandPath("/muraWRM") & "/#cmsSiteID#/includes/themes/#cmsThemeName#/");
 					$.slatwall.getService("hibachiUtilityService").duplicateDirectory(source=slatwallTemplatePath, destination=muraTemplatesPath, overwrite=false, recurse=true, copyContentExclusionList=".svn,.git");
 					
-					muraTemplatesPath = getDirectoryFromPath(expandPath("/muraWRM/#cmsSiteID#/includes/themes/#cmsThemeName#/templates/"));
+					muraTemplatesPath = getDirectoryFromPath(expandPath("/muraWRM") & "/#cmsSiteID#/includes/themes/#cmsThemeName#/templates/");
 					// Update templates to be mura specific
 					updateExampleTemlatesToBeMuraSpecific(muraTemplatesPath=muraTemplatesPath);
 					


### PR DESCRIPTION
...lways works consistently when we use a know root mapping/path.

Use getDirectoryFromPath(expandPath("/Slatwall") & "/public/views/templates") and same for /muraWRM.