### PR TITLE
excluding the apps folder from deletion when updating slatwall

### DIFF
--- a/model/service/UpdateService.cfc
+++ b/model/service/UpdateService.cfc
@@ -59,7 +59,7 @@ Notes:
 			<cfset var downloadURL = "https://github.com/ten24/Slatwall/zipball/#arguments.branch#" />	
 			<cfset var slatwallRootPath = expandPath("/Slatwall") />
 			<cfset var downloadFileName = "slatwall#createUUID()#.zip" />
-			<cfset var deleteDestinationContentExclusionList = "/integrationServices,/custom,/WEB-INF,.project,setting.xml" />
+			<cfset var deleteDestinationContentExclusionList = "/apps,/integrationServices,/custom,/WEB-INF,.project,setting.xml" />
 			<cfset var copyContentExclusionList = "" />
 			<cfset var slatwallDirectoryList = "" />
 			


### PR DESCRIPTION
adding the apps folder to the exclusions list when updating slatwall