### PR TITLE
Update default.cfm

### DIFF
--- a/admin/layouts/default.cfm
+++ b/admin/layouts/default.cfm
@@ -389,7 +389,7 @@ Notes:
 
 		<script type="text/javascript" src="#request.slatwallScope.getBaseUrl()#/?slatAction=api:js.ngslatwall&instantiationKey=#$.slatwall.getApplicationValue('instantiationKey')#"></script>
 		<cfif request.slatwallScope.getApplicationValue('debugFlag')>
-			<cfset es5scriptPath = expandPath('/admin/client/js/es5/')>
+			<cfset es5scriptPath = expandPath('/Slatwall/admin/client/js/es5/')>
 			<cfdirectory name="es5Javascript" 
 						action="list" 
 						directory="#es5scriptPath#"


### PR DESCRIPTION
Minor path change to make it consistent with the rest of the expandpaths() in slatwall - Modules weren't loading with debugFlag=true under mura