### PR TITLE
fixes how update calculated properties works so that when multiple

### DIFF
--- a/model/service/OrderService.cfc
+++ b/model/service/OrderService.cfc
@@ -1495,6 +1495,11 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 			
 			// Re-Calculate tax now that the new promotions and price groups have been applied
 			getTaxService().updateOrderAmountsWithTaxes( arguments.order );
+			
+			//update the calculated properties
+			arguments.order.setUpdateRunFlag(false);
+			arguments.order.updateCalculatedProperties();
+			
 		}
 		return arguments.order;
 	}
@@ -2398,8 +2403,6 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 			
 			// Recalculate the order amounts
 			this.processOrder( order, {}, 'updateOrderAmounts' );
-			order.updateCalculatedProperties();
-			
 			getHibachiEventService().announceEvent("afterOrderItemDelete", arguments);
 			getHibachiEventService().announceEvent("afterOrderItemDeleteSuccess", arguments);
 			

--- a/org/Hibachi/HibachiEntity.cfc
+++ b/org/Hibachi/HibachiEntity.cfc
@@ -13,7 +13,8 @@ component output="false" accessors="true" persistent="false" extends="HibachiTra
 	// Audit Properties
 	property name="createdByAccount" persistent="false";
 	property name="modifiedByAccount" persistent="false";
-	
+	property name="updateRunFlag" persistent="false";
+	   
 	// @hint global constructor arguments.  All Extended entities should call super.init() so that this gets called
 	public any function init() {
 		variables.processObjects = {};
@@ -34,31 +35,32 @@ component output="false" accessors="true" persistent="false" extends="HibachiTra
 		
 		return super.init();
 	}
-	
-	public void function updateCalculatedProperties() {
-		if(!structKeyExists(variables, "calculatedUpdateRunFlag")) {
-			// Set calculated to true so that this only runs 1 time per request
-			variables.calculatedUpdateRunFlag = true;
-			
-			// Loop over all properties
-			for(var property in getProperties()) {
-			
-				// Look for any that start with the calculatedXXX naming convention
-				if(left(property.name, 10) == "calculated") {
-					
-					var value = this.invokeMethod("get#right(property.name, len(property.name)-10)#");
-					if(!isNull(value)) {
-						variables[ property.name ] = value;	
-					}
 
-				} else if (structKeyExists(property, "hb_cascadeCalculate") && property.hb_cascadeCalculate && structKeyExists(variables, property.name) && isObject( variables[ property.name ] ) ) {
-					
-					variables[ property.name ].updateCalculatedProperties();
-					
-				}
-			}
-		}
-	}
+	/** runs a update calculated properties only once per request unless explicitly set to false before calling. */
+	public void function updateCalculatedProperties() {
+        if(!structKeyExists(variables, "updateRunFlag") || variables.updateRunFlag == false) {
+            // Set calculated to true so that this only runs 1 time per request unless explicitly told to run again.
+            
+            // Loop over all properties
+            for(var property in getProperties()) {
+                
+                // Look for any that start with the calculatedXXX naming convention
+                if(left(property.name, 10) == "calculated" && (!structKeyExists(property, "persistent") || property.persistent == "true")) {
+                    
+                    var value = this.invokeMethod("get#right(property.name, len(property.name)-10)#");
+                    if(!isNull(value)) {
+                        variables[ property.name ] = value; 
+                    }
+
+                } else if (structKeyExists(property, "hb_cascadeCalculate") && property.hb_cascadeCalculate && structKeyExists(variables, property.name) && isObject( variables[ property.name ] ) ) {
+                    
+                    variables[ property.name ].updateCalculatedProperties();
+                    
+                }
+            }
+            variables.updateRunFlag = true;
+        }
+    }
 	
 	// @hint return a simple representation of this entity
 	public string function getSimpleRepresentation() {


### PR DESCRIPTION
transactions happen during a single request, there is a way for allowing
the updated to fire multiple times as needed.

The issue: If more than one transaction was firing during a request such as removing an orderitem before adding an orderitem, if an update calculated properties was called more than once, it was only firing one time. This pull request allow a person to explicitly update calculated properties more than once if needed.
You can do that, by setting setUpdateRunFlag(false) before calling updateCalculatedProperties().

Searched for references for that variable that had its name changed: CalculatedUpdateRunFlag and didn't find any.
