### PR TITLE
Check if the entity don't have multiple property identifier then use …

### DIFF
--- a/org/Hibachi/HibachiSmartList.cfc
+++ b/org/Hibachi/HibachiSmartList.cfc
@@ -744,6 +744,10 @@ component accessors="true" persistent="false" output="false" extends="HibachiObj
 	}
 	
 	public string function getBaseEntityPrimaryAliase() {
+		var idColumnNames = getService("hibachiService").getEntityORMMetaDataObject( getBaseEntityName() ).getIdentifierColumnNames();
+		if( arrayLen(idColumnNames) > 1) {
+			return getAliasedProperty( getService("hibachiService").getPrimaryIDPropertyNameByEntityName( getBaseEntityName() ) );
+		}
 		return "#variables.entities[ getBaseEntityName() ].entityAlias#.id";
 	}
 	


### PR DESCRIPTION
…".id" instead of

calling getPrimaryIDPropertyNameByEntityName