### PR TITLE
Fixing Pagination and Duplicate Search Results in Bundle Search

### DIFF
--- a/admin/client/ts/directives/productBundleGroup/swproductbundlegroup.ts
+++ b/admin/client/ts/directives/productBundleGroup/swproductbundlegroup.ts
@@ -35,6 +35,8 @@ module slatwalladmin {
 		public filterTemplatePath;  
 		public productBundleGroupFilters; 
 		public index; 
+		public keyword; 
+		public filterTerm; 
 		public loading; 
 		public searchOptions; 
 		public value;
@@ -42,6 +44,7 @@ module slatwalladmin {
 		public collectionConfig; 
 		public selected; 
 		public searchCollectionConfig; 
+		public searchAllCollectionConfigs;
 		public formName;
 		public filterPropertiesList;
 		public totalPages;
@@ -63,6 +66,7 @@ module slatwalladmin {
 			this.showAdvanced = false;
 			this.currentPage = 1;
 			this.pageShow = 10;
+			this.searchAllCollectionConfigs = [];
 			
 			/*this.skuCollectionConfig = { 
 				baseEntityName:"Sku",
@@ -172,6 +176,9 @@ module slatwalladmin {
 		};
 		
 	    public getFiltersByTerm = (keyword,filterTerm) =>{
+			//save search 
+			this.keyword = keyword; 
+			this.filterTerm = filterTerm; 
 			this.loading = true;
 			this.showAll = true;
 			var _loadingCount;
@@ -190,23 +197,24 @@ module slatwalladmin {
 						if(i > 0){
 							var option = this.searchOptions.options[i];
 							((keyword,option) =>{
-						
-								var searchAllCollectionConfig = this.collectionConfigService.newCollectionConfig(this.searchOptions.options[i].value); 
+								if(this.searchAllCollectionConfigs.length < 4){
+									this.searchAllCollectionConfigs.push(this.collectionConfigService.newCollectionConfig(this.searchOptions.options[i].value)); 
+								}
 								
-								searchAllCollectionConfig.setKeywords(keyword); 
-								searchAllCollectionConfig.setCurrentPage(this.currentPage); 
-								searchAllCollectionConfig.setPageShow(this.pageShow); 
+								this.searchAllCollectionConfigs[i-1].setKeywords(keyword); 
+								this.searchAllCollectionConfigs[i-1].setCurrentPage(this.currentPage); 
+								this.searchAllCollectionConfigs[i-1].setPageShow(this.pageShow); 
 								//searchAllCollectionConfig.setAllRecords(true);
 								
 								
-								searchAllCollectionConfig.getEntity().then((value)=>{
+								this.searchAllCollectionConfigs[i-1].getEntity().then((value)=>{
 									
 									this.recordsCount = value.recordsCount;
 									this.pageRecordsStart = value.pageRecordsStart;
 									this.pageRecordsEnd = value.pageRecordsEnd;
 									this.totalPages = value.totalPages;
 									
-									var formattedProductBundleGroupFilters = this.productBundleService.formatProductBundleGroupFilters(value.pageRecords,option);
+									var formattedProductBundleGroupFilters = this.productBundleService.formatProductBundleGroupFilters(value.pageRecords,option,this.productBundleGroup.data.skuCollectionConfig.filterGroups[this.index].filterGroup);
 									
 									for(var j in formattedProductBundleGroupFilters){
 										if(this.productBundleGroup.data.skuCollectionConfig.filterGroups[this.index].filterGroup.indexOf(formattedProductBundleGroupFilters[j]) == -1){
@@ -222,6 +230,9 @@ module slatwalladmin {
 										//This sorts the array of objects by the objects' "type" property alphabetically
 										this.productBundleGroupFilters.value = this.utilityservice.arraySorter(this.productBundleGroupFilters.value, ["type","name"]);
 										this.$log.debug(this.productBundleGroupFilters.value);
+										if(this.productBundleGroupFilters.value.length == 0){
+											this.currentPage = 0;
+										}
 										
 									}
 									this.loading = false;
@@ -231,21 +242,23 @@ module slatwalladmin {
 					}
 				}else{
 					this.showAll = false; 
-					this.searchCollectionConfig = this.collectionConfigService.newCollectionConfig(filterTerm.value); 
-								
+					
+					if(angular.isUndefined(this.searchCollectionConfig) || filterTerm.value != this.searchCollectionConfig.baseEntityName){
+						this.searchCollectionConfig = this.collectionConfigService.newCollectionConfig(filterTerm.value); 
+					}		
 					this.searchCollectionConfig.setKeywords(keyword); 
 					this.searchCollectionConfig.setCurrentPage(this.currentPage); 
 					this.searchCollectionConfig.setPageShow(this.pageShow); 
 						
 					this.searchCollectionConfig.getEntity().then((value)=>{
 						
-						this.recordsCount = value.recordsCount;
+						this.recordsCount = value.recordsCount;			
 						this.pageRecordsStart = value.pageRecordsStart;
 						this.pageRecordsEnd = value.pageRecordsEnd;
 						this.totalPages = value.totalPages;
 						this.$log.debug('getFiltersByTerm');
 						this.$log.debug(value);
-						this.productBundleGroupFilters.value = this.productBundleService.formatProductBundleGroupFilters(value.pageRecords,filterTerm) || [];
+						this.productBundleGroupFilters.value = this.productBundleService.formatProductBundleGroupFilters(value.pageRecords,filterTerm,this.productBundleGroup.data.skuCollectionConfig.filterGroups[this.index].filterGroup) || [];
 						this.loading = false;
 					});
 				}
@@ -254,14 +267,13 @@ module slatwalladmin {
 		
 		
 		public addFilterToProductBundle = (filterItem,include,index) =>{
-			
+
 			var collectionFilterItem = new CollectionFilterItem(
 					filterItem.name, filterItem.type, 
 					filterItem.type, filterItem.propertyIdentifier,  
 					filterItem[filterItem.entityType.charAt(0).toLowerCase() + filterItem.entityType.slice(1)+'ID'], 
 					filterItem[filterItem.entityType.charAt(0).toLowerCase() + filterItem.entityType.slice(1)+'ID']
 				);
-			
 			if(include === false){
 				collectionFilterItem.comparisonOperator = '!=';
 			}else{
@@ -272,12 +284,34 @@ module slatwalladmin {
 				collectionFilterItem.logicalOperator = 'OR';
 			}
 			
+			if(angular.isDefined(this.searchCollectionConfig)){
+				this.searchCollectionConfig.addFilter(this.searchCollectionConfig.baseEntityName+"ID", collectionFilterItem.value, "!=");
+			} 
+			if(this.showAll){
+				switch(collectionFilterItem.type){
+					case 'Product Type':
+						this.searchAllCollectionConfigs[0].addFilter("productTypeID", collectionFilterItem.value, "!=");
+						break;
+					case 'Brand':
+						this.searchAllCollectionConfigs[1].addFilter("brandID", collectionFilterItem.value, "!=");
+						break;
+					case 'Products':
+						this.searchAllCollectionConfigs[2].addFilter("productID", collectionFilterItem.value, "!=");
+						break;
+					case 'Skus':
+						this.searchAllCollectionConfigs[3].addFilter("skuID", collectionFilterItem.value, "!=");
+						break;
+				}
+			}
+			
 			//Adds filter item to designated filtergroup
 			this.productBundleGroup.data.skuCollectionConfig.filterGroups[this.index].filterGroup.push(collectionFilterItem);
 			
 			//Removes the filter item from the left hand search result
-			this.productBundleGroupFilters.value.splice(index,1);
+			//this.productBundleGroupFilters.value.splice(index,1);
 			this.productBundleGroup.forms[this.formName].skuCollectionConfig.$setDirty();
+			
+			this.getFiltersByTerm(this.keyword, this.filterTerm);
 		}
 				
 		public removeProductBundleGroupFilter = (index) =>{
@@ -286,8 +320,31 @@ module slatwalladmin {
 			//Sorts Array
 			this.productBundleGroupFilters.value = this.utilityservice.arraySorter(this.productBundleGroupFilters.value, ["type","name"]);
 			//Removes the filter item from the filtergroup
-			this.productBundleGroup.data.skuCollectionConfig.filterGroups[this.index].filterGroup.splice(index,1);
+			var collectionFilterItem = this.productBundleGroup.data.skuCollectionConfig.filterGroups[this.index].filterGroup.splice(index,1)[0];
+			
+			if(angular.isDefined(this.searchCollectionConfig)){
+				this.searchCollectionConfig.removeFilter(this.searchCollectionConfig.baseEntityAlias + '.' + this.searchCollectionConfig.baseEntityName+"ID", collectionFilterItem.value, "!=");
+			} 
+			if(this.showAll){
+				switch(collectionFilterItem.type){
+					case 'Product Type':
+						this.searchAllCollectionConfigs[0].removeFilter("_productType.productTypeID", collectionFilterItem.value, "!=");
+						break;
+					case 'Brand':
+						this.searchAllCollectionConfigs[1].removeFilter("_brand.brandID", collectionFilterItem.value, "!=");
+						break;
+					case 'Products':
+						this.searchAllCollectionConfigs[2].removeFilter("_product.productID", collectionFilterItem.value, "!=");
+						break;
+					case 'Skus':
+						this.searchAllCollectionConfigs[3].removeFilter("_sku.skuID", collectionFilterItem.value, "!=");
+						break;
+				}
+			}
+			
 			this.productBundleGroup.forms[this.formName].skuCollectionConfig.$setDirty();
+			
+			this.getFiltersByTerm(this.keyword, this.filterTerm);
 		};		
 	}
 	

--- a/admin/client/ts/services/collectionconfigservice.ts
+++ b/admin/client/ts/services/collectionconfigservice.ts
@@ -174,7 +174,7 @@ module slatwalladmin{
             var _propertyIdentifier = '',
                 propertyIdentifierParts = propertyIdentifier.split('.'),
                 current_collection = this.collection;
-
+                
             for (var i = 0; i < propertyIdentifierParts.length; i++) {
 
                 if ('cfc' in current_collection.metaData[propertyIdentifierParts[i]]) {
@@ -334,10 +334,15 @@ module slatwalladmin{
             //if filterGroups is longer than 0 then we at least need to default the logical Operator to AND
             if(this.filterGroups[0].filterGroup.length && !logicalOperator) logicalOperator = 'AND';
 
+              if(propertyIdentifier.split('.').length < 2){
+                var join = false; 
+              } else { 
+                var join = true;
+              }
 
             //create filter group
             var filter = new Filter(
-                this.formatPropertyIdentifier(propertyIdentifier, true),
+                this.formatPropertyIdentifier(propertyIdentifier, join),
                 value,
                 comparisonOperator,
                 logicalOperator,
@@ -346,6 +351,27 @@ module slatwalladmin{
             );
 
             this.filterGroups[0].filterGroup.push(filter);
+        };
+        
+        public removeFilter = (propertyIdentifier: string, value: any, comparisonOperator: string = '=')=>{
+            this.removeFilterHelper(this.filterGroups, propertyIdentifier, value, comparisonOperator);
+        }
+        
+        public removeFilterHelper = (filter:any, propertyIdentifier:string, value:any, comparisonOperator:string, currentGroup?)=>{
+            if(angular.isUndefined(currentGroup)){
+                currentGroup = filter;
+            }
+            if(angular.isArray(filter)){
+                angular.forEach(filter,(key)=>{
+                    this.removeFilterHelper(key, propertyIdentifier, value, comparisonOperator, filter);
+                })
+            }else if(angular.isArray(filter.filterGroup)){
+                this.removeFilterHelper(filter.filterGroup, propertyIdentifier, value, comparisonOperator, filter.filterGroup);
+            }else{
+                if(filter.propertyIdentifier == propertyIdentifier && filter.value == value && filter.comparisonOperator == comparisonOperator){
+                    currentGroup.splice(currentGroup.indexOf(filter), 1);
+                }
+            }
         };
 
         public addCollectionFilter= (propertyIdentifier: string, displayPropertyIdentifier:string, displayValue:string,


### PR DESCRIPTION
refactoring product bundles to keep its collection configs to fix pagination and to not show duplicates in search results. Added a removeFilter method to collection config and fixed a bug with joins being forced when not needed in addFilter