### PR TITLE
handling case for when a renewal order has been cancelled

### DIFF
--- a/model/process/SubscriptionUsage_Renew.cfc
+++ b/model/process/SubscriptionUsage_Renew.cfc
@@ -104,7 +104,7 @@ component output="false" accessors="true" extends="HibachiProcess" {
 	public any function getOrder() {
 		if(!structKeyExists(variables, "order")) {
 			for(var subscriptionOrderItem in getSubscriptionUsage().getSubscriptionOrderItems()) {
-				if(subscriptionOrderItem.getSubscriptionOrderItemType().getSystemCode() == 'soitRenewal' && subscriptionOrderItem.getOrderItem().getOrder().getOrderStatusType().getSystemCode() != 'ostClosed') {
+				if(subscriptionOrderItem.getSubscriptionOrderItemType().getSystemCode() == 'soitRenewal' && subscriptionOrderItem.getOrderItem().getOrder().getStatusCode() != 'ostClosed' && subscriptionOrderItem.getOrderItem().getOrder().getStatusCode() != 'ostCanceled') {
 					variables.order = subscriptionOrderItem.getOrderItem().getOrder();
 					break;
 				}


### PR DESCRIPTION
prevents a locked state where you can't renew