### PR TITLE
Update AttributeValue.cfc

### DIFF
--- a/model/entity/AttributeValue.cfc
+++ b/model/entity/AttributeValue.cfc
@@ -666,6 +666,9 @@ component displayname="Attribute Value" entityname="SlatwallAttributeValue" tabl
 			&& len(getAttribute().getAttributeCode())
 			&& !isNull(getAttribute().getAttributeInputType())
 			&& getAttribute().getAttributeInputType() == 'file') {
+			
+			var preExistingFilePath = getAttribute().getAttributeValueUploadDirectory() & arguments.attributeValue;
+			writeLog(file="Slatwall", text="Detail Log - FilePath > #preExistingFilePath#");
 
 			// Make sure that a new value was passed in to be set
 			if(structKeyExists(form, getAttribute().getAttributeCode()) && len(form[getAttribute().getAttributeCode()])) {
@@ -689,6 +692,10 @@ component displayname="Attribute Value" entityname="SlatwallAttributeValue" tabl
 					// Add an error if there were any hard errors during upload
 					this.addError('attributeValue', rbKey('validate.fileUpload'));
 				}
+			} elseif ( fileExists(preExistingFilePath) ) {
+				
+				// condition where file has already been uploaded to the default upload dir
+				variables.attributeValue = arguments.attributeValue;
 			}
 		} else {
 			// Set the value


### PR DESCRIPTION
We've been working with a webservice that returns a binary file, that we pre-upload from the response. The file is needed to be viewable as a custom Attribute. setAttributeValue()'s condition to check for a 'form' key has recently broken this function. We propose a mod to check for a pre-existing file path so that a File Attribute can be used in both modes.