### PR TITLE
Update Content.cfc

### DIFF
--- a/model/entity/Content.cfc
+++ b/model/entity/Content.cfc
@@ -57,8 +57,8 @@ component displayname="Content" entityname="SlatwallContent" table="SwContent" p
 	property name="allowPurchaseFlag" ormtype="boolean";
 	property name="productListingPageFlag" ormtype="boolean";
 	property name="urlTitle" ormtype="string" length="4000";
-	property name="urlTitlePath" ormtype="string" length="8000";
-	property name="contentBody" ormtype="string" length="8000" ;
+	property name="urlTitlePath" ormtype="clob";
+	property name="contentBody" ormtype="clob";
 	property name="displayInNavigation" ormtype="boolean";
 	property name="excludeFromSearch" ormtype="boolean";
 	property name="sortOrder" ormtype="integer";


### PR DESCRIPTION
Suggestion to use CLOB here for ormtype value on urlTitlePath and contentBody. An ormtype of "string" with a length of 8000 causes issues on Oracle databases. 

Since the max length of a VARCHAR2 field on Oracle is 4000 characters, Hibernate converts this to a LONG data type which are somewhat deprecated. A table cannot contain more than one LONG column, causing the Slatwall reload to fail (silently on Railo/Lucee). 

This took a VERY long time to track down but changing the types here seems to address it. Just wanted to open this up for now as it might need further exploration / discussion.