### PR TITLE
Added ability to define session domain for sub-domain sharing

### DIFF
--- a/org/Hibachi/Hibachi.cfc
+++ b/org/Hibachi/Hibachi.cfc
@@ -1,9 +1,9 @@
 component extends="FW1.framework" {
-	
+
 	// ======= START: ENVIORNMENT CONFIGURATION =======
 
 	// =============== configApplication
-	
+
 	// Defaults
 	this.name = "hibachi" & hash(getCurrentTemplatePath());
 	this.sessionManagement = true;
@@ -11,16 +11,16 @@ component extends="FW1.framework" {
 	this.datasource.name = "hibachi";
 	this.datasource.username = "";
 	this.datasource.password = "";
-	
+
 	// Allow For Application Config
 	try{include "../../config/configApplication.cfm";}catch(any e){}
 	// Allow For Instance Config
 	try{include "../../custom/config/configApplication.cfm";}catch(any e){}
-	
+
 	// =============== configFramework
-	
+
 	// Defaults
-	
+
 	// FW1 Setup
 	variables.framework=structNew();
 	variables.framework.applicationKey = 'Hibachi';
@@ -35,13 +35,13 @@ component extends="FW1.framework" {
 	variables.framework.subsystemDelimiter = ':';
 	variables.framework.siteWideLayoutSubsystem = 'common';
 	variables.framework.home = 'admin:main.default';
-  	variables.framework.error = 'admin:error.default';
-  	variables.framework.reload = 'reload';
-  	variables.framework.password = 'true';
-  	variables.framework.reloadApplicationOnEveryRequest = false;
-  	variables.framework.generateSES = false;
-  	variables.framework.SESOmitIndex = false;
-  	variables.framework.suppressImplicitService = true;
+	variables.framework.error = 'admin:error.default';
+	variables.framework.reload = 'reload';
+	variables.framework.password = 'true';
+	variables.framework.reloadApplicationOnEveryRequest = false;
+	variables.framework.generateSES = false;
+	variables.framework.SESOmitIndex = false;
+	variables.framework.suppressImplicitService = true;
 	variables.framework.unhandledExtensions = 'cfc';
 	variables.framework.unhandledPaths = '/flex2gateway';
 	variables.framework.unhandledErrorCaught = false;
@@ -49,7 +49,7 @@ component extends="FW1.framework" {
 	variables.framework.maxNumContextsPreserved = 10;
 	variables.framework.cacheFileExists = false;
 	variables.framework.trace = false;
-	
+
 	/* TODO: add solution to api routing for Rest api*/
 	variables.framework.routes = [
 		//api routes
@@ -57,21 +57,21 @@ component extends="FW1.framework" {
 		 { "$GET/api/scope/$" = "/api:public/get/" }
 		,{ "$GET/api/scope/:context/$" = "/api:public/get/context/:context"}
 		,{ "$POST/api/scope/:context/$" = "/api:public/post/context/:context"}
-		
+
 		,{ "$POST/api/auth/login/$" = "/api:main/login"}
 		,{ "$GET/api/auth/login/$" = "/api:main/login"}
-		
+
 		,{ "$POST/api/log/$" = "/api:main/log"}
-		
+
 		,{ "$GET/api/$" = "/api:main/get/" }
 		,{ "$GET/api/:entityName/$" = "/api:main/get/entityName/:entityName"}
 		,{ "$GET/api/:entityName/:entityID/$" = "/api:main/get/entityName/:entityName/entityID/:entityID"}
-		
+
 		,{ "$POST/api/" = "/api:main/post/" }
 		,{ "$POST/api/:entityName/:entityID" = "/api:main/post/entityName/:entityName/entityID/:entityID"}
-		
+
 	];
-	
+
 	// Hibachi Setup
 	variables.framework.hibachi = {};
 	variables.framework.hibachi.authenticationSubsystems = "admin,public,api";
@@ -87,43 +87,43 @@ component extends="FW1.framework" {
 	variables.framework.hibachi.loginDefaultSection = 'main';
 	variables.framework.hibachi.loginDefaultItem = 'login';
 	variables.framework.hibachi.useCachingEngineFlag = false;
-	
 	variables.framework.hibachi.noaccessDefaultSubsystem = 'admin';
 	variables.framework.hibachi.noaccessDefaultSection = 'main';
 	variables.framework.hibachi.noaccessDefaultItem = 'noaccess';
-	variables.framework.hibachi.lineBreakStyle="#server.os.name#";
-	
+	variables.framework.hibachi.sessionCookieDomain = CGI.HTTP_HOST;
+	variables.framework.hibachi.lineBreakStyle = SERVER.OS.NAME;
+
 	// Allow For Application Config
 	try{include "../../config/configFramework.cfm";}catch(any e){}
 	// Allow For Instance Config
 	try{include "../../custom/config/configFramework.cfm";}catch(any e){}
-	
-	
+
+
 	// =============== configMappings
-	
+
 	// Defaults
 	this.mappings[ "/#variables.framework.applicationKey#" ] = replace(replace(getDirectoryFromPath(getCurrentTemplatePath()),"\","/","all"), "/org/Hibachi/", "");
-	
-	// Allow For Application Config 
+
+	// Allow For Application Config
 	try{include "../../config/configMappings.cfm";}catch(any e){}
 	// Allow For Instance Config
 	try{include "../../custom/config/configMappings.cfm";}catch(any e){}
-	
-	
+
+
 	// =============== configCustomTags
-	
-	// Allow For Application Config 
+
+	// Allow For Application Config
 	try{include "../../config/configCustomTags.cfm";}catch(any e){}
 	// Allow For Instance Config
 	try{include "../../custom/config/configCustomTags.cfm";}catch(any e){}
-	
-	// set the custom tag mapping 
+
+	// set the custom tag mapping
 	if(structKeyExists(this, "customTagPathsArray") && isArray(this.customTagPathsArray) && arrayLen(this.customTagPathsArray)) {
-		this.customTagPaths = arrayToList(this.customTagPathsArray);	
+		this.customTagPaths = arrayToList(this.customTagPathsArray);
 	}
-	
+
 	// =============== configORM
-	
+
 	// Defaults
 	this.ormenabled = true;
 	this.ormsettings = {};
@@ -137,30 +137,30 @@ component extends="FW1.framework" {
 	this.ormSettings.useDBforMapping = false;
 	this.ormSettings.autogenmap = true;
 	this.ormSettings.logsql = false;
-	
-	// Allow For Application Config 
+
+	// Allow For Application Config
 	try{include "../../config/configORM.cfm";}catch(any e){}
 	// Allow For Instance Config
 	try{include "../../custom/config/configORM.cfm";}catch(any e){}
-	
+
 	// ==================== START: PRE UPDATE SCRIPTS ======================
 	if(!fileExists("#this.mappings[ '/#variables.framework.applicationKey#' ]#/custom/config/lastFullUpdate.txt.cfm") || !fileExists("#this.mappings[ '/#variables.framework.applicationKey#' ]#/custom/config/preUpdatesRun.txt.cfm") || (structKeyExists(url, variables.framework.hibachi.fullUpdateKey) && url[ variables.framework.hibachi.fullUpdateKey ] == variables.framework.hibachi.fullUpdatePassword)){
-		
+
 		this.ormSettings.secondaryCacheEnabled = false;
-		
+
 		variables.preupdate = {};
-		
+
 		if(!fileExists("#this.mappings[ '/#variables.framework.applicationKey#' ]#/custom/config/preUpdatesRun.txt.cfm")) {
 			fileWrite("#this.mappings[ '/#variables.framework.applicationKey#' ]#/custom/config/preUpdatesRun.txt.cfm", "");
 		}
-		
+
 		variables.preupdate.preUpdatesRun = fileRead("#this.mappings[ '/#variables.framework.applicationKey#' ]#/custom/config/preUpdatesRun.txt.cfm");
-		
-		
-		
+
+
+
 		// Loop over and run any pre-update files
 		variables.preupdate.preUpdateFiles = directoryList("#this.mappings[ '/#variables.framework.applicationKey#' ]#/config/scripts/preupdate");
-		
+
 		for(variables.preupdate.preUpdateFullFilename in variables.preupdate.preUpdateFiles) {
 			variables.preupdate.thisFilename = listLast(variables.preupdate.preUpdateFullFilename, "/\");
 			if(!listFindNoCase(variables.preupdate.preUpdatesRun, variables.preupdate.thisFilename)) {
@@ -168,25 +168,25 @@ component extends="FW1.framework" {
 				variables.preupdate.preUpdatesRun = listAppend(variables.preupdate.preUpdatesRun, variables.preupdate.thisFilename);
 			}
 		}
-		
+
 		fileWrite("#this.mappings[ '/#variables.framework.applicationKey#' ]#/custom/config/preUpdatesRun.txt.cfm", variables.preupdate.preUpdatesRun);
 	}
 	// ==================== END: PRE UPDATE SCRIPTS ======================
-	
+
 	// =======  END: ENVIORNMENT CONFIGURATION  =======
-	
+
 	public any function bootstrap() {
 		setupGlobalRequest();
-		
+
 		// Announce the applicatoinRequest event
 		getHibachiScope().getService("hibachiEventService").announceEvent(eventName="onApplicationBootstrapRequestStart");
-		
+
 		return getHibachiScope();
 	}
-	
+
 	public any function reloadApplication() {
 		setupApplicationWrapper();
-		
+
 		lock name="application_#getHibachiInstanceApplicationScopeKey()#_initialized" timeout="10" {
 			if( !structKeyExists(application, getHibachiInstanceApplicationScopeKey()) ) {
 				application[ getHibachiInstanceApplicationScopeKey() ] = {};
@@ -194,7 +194,7 @@ component extends="FW1.framework" {
 			application[ getHibachiInstanceApplicationScopeKey() ].initialized = false;
 		}
 	}
-	
+
 	public void function setupGlobalRequest() {
 		if(!structKeyExists(request, "#variables.framework.applicationKey#Scope")) {
             if(fileExists(expandPath('/#variables.framework.applicationKey#') & "/custom/model/transient/HibachiScope.cfc")) {
@@ -202,7 +202,7 @@ component extends="FW1.framework" {
             } else {
                 request["#variables.framework.applicationKey#Scope"] = createObject("component", "#variables.framework.applicationKey#.model.transient.HibachiScope").init();
             }
-			
+
 			// Verify that the application is setup
 			verifyApplicationSetup();
 			// Verify that the session is setup
@@ -214,7 +214,7 @@ component extends="FW1.framework" {
 				//get token by stripping prefix
 				var token = right(authorizationHeader,len(authorizationHeader) - len(prefix));
 				var jwt = getHibachiScope().getService('jwtService').getJwtByToken(token);
-				
+
 				if(jwt.verify()){
 					var account = getHibachiScope().getService('accountService').getAccountByAccountID(jwt.getPayload().accountid);
 					if(!isNull(account)){
@@ -223,7 +223,7 @@ component extends="FW1.framework" {
 					}
 				}
 			}
-			
+
 			// If there is no account on the session, then we can look for an authToken to setup that account for this one request
 			if(!getHibachiScope().getLoggedInFlag() && structKeyExists(request, "context") && structKeyExists(request.context, "authToken") && len(request.context.authToken)) {
 				var authTokenAccount = getHibachiScope().getDAO('hibachiDAO').getAccountByAuthToken(authToken=request.context.authToken);
@@ -231,7 +231,7 @@ component extends="FW1.framework" {
 					getHibachiScope().getSession().setAccount( authTokenAccount );
 				}
 			}
-			
+
 			// Call the onEveryRequest() Method for the parent Application.cfc
 			onEveryRequest();
 		}
@@ -239,7 +239,7 @@ component extends="FW1.framework" {
 			getHibachiScope().getService("hibachiEventService").announceEvent(eventName="setupGlobalRequestComplete");
 		}
 	}
-	
+
 	public void function setupRequest() {
 		setupGlobalRequest();
 		var httpRequestData = getHTTPRequestData();
@@ -256,7 +256,7 @@ component extends="FW1.framework" {
 					var jsonString = "";
 					if (isBinary(httpRequestData.content)){
 						jsonString = charsetEncode( httpRequestData.content, "utf-8" );
-					}else{	
+					}else{
 						jsonString = httpRequestData.content;
 					}
 					if (isJSON(jsonString)){
@@ -272,8 +272,8 @@ component extends="FW1.framework" {
 		}else if(structKeyExists(request.context, 'serializedJSONData') && isSimpleValue(request.context.serializedJSONData) && isJSON(request.context.serializedJSONData)) {
 			request.context["deserializedJsonData"] = deserializeJSON(request.context.serializedJSONData);
 			hasJsonData = true;
-		} 
-		
+		}
+
 		/* Figure out if this is a public request */
 		request.context["url"] = getHibachiScope().getURL();
 		if (FindNoCase("/api/scope", request.context["url"]) ){
@@ -282,9 +282,9 @@ component extends="FW1.framework" {
 		}else{
 			request.context["usePublicAPI"] = false;
 		}
-		
+
 		application[ "#variables.framework.applicationKey#Bootstrap" ] = this.bootstrap;
-		
+
 		var restInfo = {};
 		//prepare restinfo
 		if(listFirst( request.context[ getAction() ], ":" ) == 'api'){
@@ -297,18 +297,18 @@ component extends="FW1.framework" {
 				restInfo.context = request.context.context;
 			}
 		}
-		
-		var authorizationDetails = getHibachiScope().getService("hibachiAuthenticationService").getActionAuthenticationDetailsByAccount(action=request.context[ getAction() ] , account=getHibachiScope().getAccount(), restInfo=restInfo);	
+
+		var authorizationDetails = getHibachiScope().getService("hibachiAuthenticationService").getActionAuthenticationDetailsByAccount(action=request.context[ getAction() ] , account=getHibachiScope().getAccount(), restInfo=restInfo);
 		// Verify Authentication before anything happens
 		if(
-			!authorizationDetails.authorizedFlag 
+			!authorizationDetails.authorizedFlag
 		) {
 			// Get the hibachiConfig out of the application scope in case any changes were made to it
 			var hibachiConfig = getHibachiScope().getApplicationValue("hibachiConfig");
-			
+
 			// setup the success redirect URL as this current page
 			request.context.sRedirectURL = getHibachiScope().getURL();
-			
+
 			// make sure there are no reload keys in the redirectURL
 			request.context.sRedirectURL = replace(request.context.sRedirectURL, "#variables.framework.reload#=#variables.framework.password#", "");
 			request.context.sRedirectURL = replace(request.context.sRedirectURL, "#variables.framework.hibachi.fullUpdateKey#=#variables.framework.hibachi.fullUpdatePassword#", "");
@@ -324,7 +324,7 @@ component extends="FW1.framework" {
 				if(!structKeyExists(request.context,'messages')){
 					request.context.messages = [];
 				}
-				
+
 				var message = {};
 				var message['messageType'] = 'error';
 				if(structKeyExists(authorizationDetails,'forbidden') && authorizationDetails.forbidden == true){
@@ -339,7 +339,7 @@ component extends="FW1.framework" {
 				}
 				arrayAppend(request.context.messages,message);
 				renderApiResponse();
-				
+
 			}
 			//Route the user to the noaccess page if they are already logged in
 			else if( getHibachiScope().getLoggedInFlag() ) {
@@ -354,34 +354,34 @@ component extends="FW1.framework" {
 					redirect(action="#getSubsystem(request.context[ getAction() ])#:#hibachiConfig.loginDefaultSection#.#hibachiConfig.loginDefaultItem#", preserve="swprid,sRedirectURL");
 				} else {
 					redirect(action="#hibachiConfig.loginDefaultSubsystem#:#hibachiConfig.loginDefaultSection#.#hibachiConfig.loginDefaultItem#", preserve="swprid,sRedirectURL");
-				}	
+				}
 			}
-			
+
 		} else if(authorizationDetails.authorizedFlag && authorizationDetails.publicAccessFlag) {
 			getHibachiScope().setPublicPopulateFlag( true );
 		}
-		
+
 		// Setup structured Data if a request context exists meaning that a full action was called
 		getHibachiScope().getService("hibachiUtilityService").buildFormCollections(request.context);
-		
+
 		// Setup a $ in the request context, and the hibachiScope shortcut
 		request.context.fw = getHibachiScope().getApplicationValue("application");
 		request.context.$ = {};
 		request.context.$[ variables.framework.applicationKey ] = getHibachiScope();
 		request.context.pagetitle = request.context.$[ variables.framework.applicationKey ].rbKey( request.context[ getAction() ] );
 		request.context.edit = false;
-		
+
 		param name="request.context.ajaxRequest" default="false";
 		param name="request.context.returnJSONObjects" default="";
 		param name="request.context.returnJSONKeyLCase" default="false";
 		param name="request.context.messages" default="#arrayNew(1)#";
-		
+
 		request.context.ajaxResponse = {};
 
 		if(structKeyExists(httpRequestData.headers, "X-Hibachi-AJAX") && isBoolean(httpRequestData.headers["X-Hibachi-AJAX"]) && httpRequestData.headers["X-Hibachi-AJAX"]) {
 			request.context.ajaxRequest = true;
 		}
-		
+
 		// Check to see if any message keys were passed via the URL
 		if(structKeyExists(request.context, "messageKeys")) {
 			var messageKeys = listToArray(request.context.messageKeys);
@@ -389,29 +389,29 @@ component extends="FW1.framework" {
 				getHibachiScope().showMessageKey( messageKeys[i] );
 			}
 		}
-		
+
 		// Call the onInternalRequest() Method for the parent Application.cfc
 		onInternalRequest();
-		
+
 		// Announce the applicatoinRequestStart event
 		getHibachiScope().getService("hibachiEventService").announceEvent(eventName="onApplicationRequestStart");
 	}
-	
+
 	public void function verifyApplicationSetup() {
 		if(structKeyExists(url, variables.framework.reload) && url[variables.framework.reload] == variables.framework.password) {
 			getHibachiScope().setApplicationValue("initialized", false);
 		}
-		
+
 		// Check to see if out application stuff is initialized
 		if(!getHibachiScope().hasApplicationValue("initialized") || !getHibachiScope().getApplicationValue("initialized")) {
 			// If not, lock the application until this is finished
 			lock scope="Application" timeout="240"  {
-				
+
 				// Check again so that the qued requests don't back up
 				if(!getHibachiScope().hasApplicationValue("initialized") || !getHibachiScope().getApplicationValue("initialized")) {
-					
+
 					// Setup the app init data
-					var applicationInitData = {}; 
+					var applicationInitData = {};
 					applicationInitData["initialized"] = 				false;
 					applicationInitData["instantiationKey"] =			createUUID();
 					applicationInitData["application"] = 				this;
@@ -434,17 +434,17 @@ component extends="FW1.framework" {
 					writeLog(file="#variables.framework.applicationKey#", text="General Log - Application setup started.");
 					for(var key in applicationInitData) {
 						if(isSimpleValue(applicationInitData[key])) {
-							writeLog(file="#variables.framework.applicationKey#", text="General Log - Application Init '#key#' as: #applicationInitData[key]#");	
+							writeLog(file="#variables.framework.applicationKey#", text="General Log - Application Init '#key#' as: #applicationInitData[key]#");
 						}
 					}
-					
+
 					// Application Setup Started
 					application[ getHibachiInstanceApplicationScopeKey() ] = applicationInitData;
 					writeLog(file="#variables.framework.applicationKey#", text="General Log - Application cache cleared, and init values set.");
 
 					//Add application name to ckfinder
 					fileWrite(expandPath('/#variables.framework.applicationKey#') & '/org/Hibachi/ckfinder/core/connector/cfm/configApplication.cfm', '<cfset this.name="#this.name#" />');
-					
+
 					// =================== Required Application Setup ===================
 					// The FW1 Application had not previously been loaded so we are going to call onApplicationStart()
 					if(!structKeyExists(application, variables.framework.applicationKey)) {
@@ -453,57 +453,57 @@ component extends="FW1.framework" {
 						writeLog(file="#variables.framework.applicationKey#", text="General Log - onApplicationStart() finished");
 					}
 					// ================ END: Required Application Setup ==================
-					
+
 					//========================= IOC SETUP ====================================
-					
+
 					var coreBF = new DI1.ioc("/#variables.framework.applicationKey#/model", {
 						transients=["entity", "process", "transient", "report"],
 						transientPattern="Bean$"
 					});
-					
+
 					coreBF.addBean("applicationKey", variables.framework.applicationKey);
 					coreBF.addBean("hibachiInstanceApplicationScopeKey", getHibachiInstanceApplicationScopeKey());
-					
+
 					// If the default singleton beans were not found in the model, add a reference to the core one in hibachi
 					if(!coreBF.containsBean("hibachiDAO")) {
-						coreBF.declareBean("hibachiDAO", "#variables.framework.applicationKey#.org.Hibachi.HibachiDAO", true);	
+						coreBF.declareBean("hibachiDAO", "#variables.framework.applicationKey#.org.Hibachi.HibachiDAO", true);
 					}
 					if(!coreBF.containsBean("hibachiService")) {
-						coreBF.declareBean("hibachiService", "#variables.framework.applicationKey#.org.Hibachi.HibachiService", true);	
+						coreBF.declareBean("hibachiService", "#variables.framework.applicationKey#.org.Hibachi.HibachiService", true);
 					}
 					if(!coreBF.containsBean("hibachiAuthenticationService")) {
-						coreBF.declareBean("hibachiAuthenticationService", "#variables.framework.applicationKey#.org.Hibachi.HibachiAuthenticationService", true);	
+						coreBF.declareBean("hibachiAuthenticationService", "#variables.framework.applicationKey#.org.Hibachi.HibachiAuthenticationService", true);
 					}
 					if(!coreBF.containsBean("hibachiCacheService")) {
-						coreBF.declareBean("hibachiCacheService", "#variables.framework.applicationKey#.org.Hibachi.HibachiCacheService", true);	
+						coreBF.declareBean("hibachiCacheService", "#variables.framework.applicationKey#.org.Hibachi.HibachiCacheService", true);
 					}
 					if(!coreBF.containsBean("hibachiDataService")) {
-						coreBF.declareBean("hibachiDataService", "#variables.framework.applicationKey#.org.Hibachi.HibachiDataService", true);	
+						coreBF.declareBean("hibachiDataService", "#variables.framework.applicationKey#.org.Hibachi.HibachiDataService", true);
 					}
 					if(!coreBF.containsBean("hibachiEventService")) {
-						coreBF.declareBean("hibachiEventService", "#variables.framework.applicationKey#.org.Hibachi.HibachiEventService", true);	
+						coreBF.declareBean("hibachiEventService", "#variables.framework.applicationKey#.org.Hibachi.HibachiEventService", true);
 					}
 					if(!coreBF.containsBean("hibachiRBService")) {
-						coreBF.declareBean("hibachiRBService", "#variables.framework.applicationKey#.org.Hibachi.HibachiRBService", true);	
+						coreBF.declareBean("hibachiRBService", "#variables.framework.applicationKey#.org.Hibachi.HibachiRBService", true);
 					}
 					if(!coreBF.containsBean("hibachiReportService")) {
-						coreBF.declareBean("hibachiReportService", "#variables.framework.applicationKey#.org.Hibachi.HibachiReportService", true);	
+						coreBF.declareBean("hibachiReportService", "#variables.framework.applicationKey#.org.Hibachi.HibachiReportService", true);
 					}
 					if(!coreBF.containsBean("hibachiSessionService")) {
-						coreBF.declareBean("hibachiSessionService", "#variables.framework.applicationKey#.org.Hibachi.HibachiSessionService", true);	
+						coreBF.declareBean("hibachiSessionService", "#variables.framework.applicationKey#.org.Hibachi.HibachiSessionService", true);
 					}
 					if(!coreBF.containsBean("hibachiTagService")) {
-						coreBF.declareBean("hibachiTagService", "#variables.framework.applicationKey#.org.Hibachi.HibachiTagService", true);	
+						coreBF.declareBean("hibachiTagService", "#variables.framework.applicationKey#.org.Hibachi.HibachiTagService", true);
 					}
 					if(!coreBF.containsBean("hibachiUtilityService")) {
-						coreBF.declareBean("hibachiUtilityService", "#variables.framework.applicationKey#.org.Hibachi.HibachiUtilityService", true);	
+						coreBF.declareBean("hibachiUtilityService", "#variables.framework.applicationKey#.org.Hibachi.HibachiUtilityService", true);
 					}
 					if(!coreBF.containsBean("hibachiValidationService")) {
-						coreBF.declareBean("hibachiValidationService", "#variables.framework.applicationKey#.org.Hibachi.HibachiValidationService", true);	
+						coreBF.declareBean("hibachiValidationService", "#variables.framework.applicationKey#.org.Hibachi.HibachiValidationService", true);
 					}
 					if(!coreBF.containsBean("hibachiCollectionService")) {
-                        coreBF.declareBean("hibachiCollectionService", "#variables.framework.applicationKey#.org.Hibachi.hibachiCollectionService", true);  
-                    } 
+                        coreBF.declareBean("hibachiCollectionService", "#variables.framework.applicationKey#.org.Hibachi.hibachiCollectionService", true);
+                    }
 					// If the default transient beans were not found in the model, add a reference to the core one in hibachi
 					if(!coreBF.containsBean("hibachiScope")) {
 						coreBF.declareBean("hibachiScope", "#variables.framework.applicationKey#.org.Hibachi.HibachiScope", false);
@@ -517,21 +517,21 @@ component extends="FW1.framework" {
 					if(!coreBF.containsBean("hibachiMessages")) {
 						coreBF.declareBean("hibachiMessages", "#variables.framework.applicationKey#.org.Hibachi.HibachiMessages", false);
 					}
-					
-					
+
+
 					// Setup the custom bean factory
 					if(directoryExists("#getHibachiScope().getApplicationValue("applicationRootMappingPath")#/custom/model")) {
 						var customBF = new DI1.ioc("/#variables.framework.applicationKey#/custom/model", {
 							transients=["process", "transient", "report"],
 							exclude=["entity"]
 						});
-						
+
 						// Folder argument is left blank because at this point bean discovery has already occurred and we will not be looking at directories
 						var aggregateBF = new DI1.ioc("");
-						
+
 						// Process factories, last takes precendence
 						var beanFactories = [coreBF, customBF];
-						
+
 						// Build the aggregate bean factory by manually declaring the beans
 						for (var bf in beanFactories) {
 							var beanInfo = bf.getBeanInfo().beanInfo;
@@ -548,25 +548,25 @@ component extends="FW1.framework" {
 								}
 							}
 						}
-						
+
 						setBeanFactory(aggregateBF);
 					} else {
 						setBeanFactory(coreBF);
 					}
 					writeLog(file="#variables.framework.applicationKey#", text="General Log - Bean Factory Set");
-					
+
 					//========================= END: IOC SETUP ===============================
-					
+
 					// Call the onFirstRequest() Method for the parent Application.cfc
 					onFirstRequest();
-					
+
 					// ============================ FULL UPDATE =============================== (this is only run when updating, or explicitly calling it by passing update=true as a url key)
 					if(!fileExists(expandPath('/#variables.framework.applicationKey#/custom/config') & '/lastFullUpdate.txt.cfm') || (structKeyExists(url, variables.framework.hibachi.fullUpdateKey) && url[ variables.framework.hibachi.fullUpdateKey ] == variables.framework.hibachi.fullUpdatePassword)){
 						writeLog(file="#variables.framework.applicationKey#", text="General Log - Full Update Initiated");
-						
+
 						// Set the request timeout to 360
 						getHibachiScope().getService("hibachiTagService").cfsetting(requesttimeout=600);
-						
+
 						//Update custom properties
 						var success = getHibachiScope().getService('updateService').updateEntitiesWithCustomProperties();
 						if (success){
@@ -577,42 +577,42 @@ component extends="FW1.framework" {
 						// Reload ORM
 						writeLog(file="#variables.framework.applicationKey#", text="General Log - ORMReload() started");
 						ormReload();
-						writeLog(file="#variables.framework.applicationKey#", text="General Log - ORMReload() was successful"); 
-							
+						writeLog(file="#variables.framework.applicationKey#", text="General Log - ORMReload() was successful");
+
 						onUpdateRequest();
-						
+
 						// Write File
-						fileWrite(expandPath('/#variables.framework.applicationKey#') & '/custom/config/lastFullUpdate.txt.cfm', now());				
-						
+						fileWrite(expandPath('/#variables.framework.applicationKey#') & '/custom/config/lastFullUpdate.txt.cfm', now());
+
 						// Announce the applicationFullUpdate event
 						getHibachiScope().getService("hibachiEventService").announceEvent("onApplicationFullUpdate");
 					}
 					// ========================== END: FULL UPDATE ==============================
-					
+
 					// Call the onFirstRequestPostUpdate() Method for the parent Application.cfc
 					onFirstRequestPostUpdate();
-					
+
 					//==================== START: EVENT HANDLER SETUP ========================
-					
+
 					getBeanFactory().getBean('hibachiEventService').registerEventHandlers();
-					
+
 					//===================== END: EVENT HANDLER SETUP =========================
-					
+
 					// Application Setup Ended
 					getHibachiScope().setApplicationValue("initialized", true);
 					writeLog(file="#variables.framework.applicationKey#", text="General Log - Application Setup Complete");
-					
+
 					// Announce the applicationSetup event
 					getHibachiScope().getService("hibachiEventService").announceEvent("onApplicationSetup");
-					
+
 				}
 			}
 		}
 	}
-	
+
 	public void function renderApiResponse(){
 		param name="request.context.headers.contentType" default="application/json";
-		param name="request.context.apiResponse.content" default="#structNew()#"; 
+		param name="request.context.apiResponse.content" default="#structNew()#";
 		//need response header for api
 		var context = getPageContext();
 		context.getOut().clearBuffer();
@@ -621,24 +621,24 @@ component extends="FW1.framework" {
 			response.setHeader(header,request.context.headers[header]);
 		}
 		var responseString = '';
-		
+
 		if(structKeyExists(request.context, "messages")) {
 			if(!structKeyExists(request.context.apiResponse.content,'messages')){
-				request.context.apiResponse.content["messages"] = request.context.messages;	
+				request.context.apiResponse.content["messages"] = request.context.messages;
 			}else{
 				for(var message in request.context.messages){
-					request.context.apiResponse.content["messages"];	
+					request.context.apiResponse.content["messages"];
 					arrayAppend(request.context.apiResponse.content["messages"],message);
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		//leaving a note here in case we ever wish to support XML for api responses
 		if(isStruct(request.context.apiResponse.content) && request.context.headers.contentType eq 'application/json'){
 			responseString = serializeJSON(request.context.apiResponse.content);
-			
+
 			// If running CF9 we need to fix strings that were improperly cast to numbers
 			if(left(server.coldFusion.productVersion, 1) eq 9) {
 				responseString = getHibachiScope().getService("hibachiUtilityService").updateCF9SerializeJSONOutput(responseString);
@@ -650,27 +650,27 @@ component extends="FW1.framework" {
 		writeOutput( responseString );
 		abort;
 	}
-	
+
 	public void function setupResponse() {
 		param name="request.context.ajaxRequest" default="false";
 		param name="request.context.ajaxResponse" default="#structNew()#";
 		param name="request.context.apiRequest" default="false";
 		param name="request.context.apiResponse.content" default="#structNew()#";
-		
+
 		endHibachiLifecycle();
 		// Announce the applicationRequestStart event
 		getHibachiScope().getService("hibachiEventService").announceEvent(eventName="onApplicationRequestEnd");
-		
-		
+
+
 		// Check for an API Response
 		if(request.context.apiRequest) {
 			renderApiResponse();
-		}		
+		}
 		// Check for an Ajax Response
 		if(request.context.ajaxRequest && !structKeyExists(request, "exception")) {
 			if(isStruct(request.context.ajaxResponse)){
 				if(structKeyExists(request.context, "messages")) {
-					request.context.ajaxResponse["messages"] = request.context.messages;	
+					request.context.ajaxResponse["messages"] = request.context.messages;
 				}
   				request.context.ajaxResponse["successfulActions"] = getHibachiScope().getSuccessfulActions();
   				request.context.ajaxResponse["failureActions"] = getHibachiScope().getFailureActions();
@@ -683,44 +683,44 @@ component extends="FW1.framework" {
   				}
   			}
   			if(structKeyExists(request.context, "returnJSONKeyLCase") && isBoolean(request.context.returnJSONKeyLCase) && request.context.returnJSONKeyLCase) {
-				writeOutput( serializeJSON( getHibachiScope().getService("hibachiUtilityService").lcaseStructKeys(request.context.ajaxResponse) ) );	
+				writeOutput( serializeJSON( getHibachiScope().getService("hibachiUtilityService").lcaseStructKeys(request.context.ajaxResponse) ) );
 			} else {
 				writeOutput( serializeJSON(request.context.ajaxResponse) );
 			}
 			abort;
 		}
-		
+
 	}
-	
+
 	public void function setupView() {
 		param name="request.context.ajaxRequest" default="false";
-		
+
 		if(request.context.ajaxRequest) {
 			setupResponse();
 		}
-		
+
 		if(structKeyExists(url, "modal") && url.modal) {
 			request.layout = false;
 			setLayout("#getSubsystem(request.context[ getAction() ])#:modal");
 		}
 	}
-	
+
 	// Allows for custom views to be created for the admin, frontend or public subsystems
 	public string function customizeViewOrLayoutPath( struct pathInfo, string type, string fullPath ) {
 		if(!fileExists(expandPath(arguments.fullPath)) && left(listLast(arguments.fullPath, "/"), 6) eq "create" && fileExists(expandPath(replace(arguments.fullPath, "/create", "/detail")))) {
 			return replace(arguments.fullPath, "/create", "/detail");
 		} else if(!fileExists(expandPath(arguments.fullPath)) && left(listLast(arguments.fullPath, "/"), 4) eq "edit" && fileExists(expandPath(replace(arguments.fullPath, "/edit", "/detail")))) {
 			return replace(arguments.fullPath, "/edit", "/detail");
-		}	
-	
+		}
+
 		return arguments.fullPath;
 	}
-	
-	// Override from FW/1 so that we can make it public 
+
+	// Override from FW/1 so that we can make it public
 	public string function getSubsystemDirPrefix( string subsystem ) {
 		return super.getSubsystemDirPrefix( arguments.subsystem );
 	}
-	
+
 	// This handels all of the ORM persistece.
 	public void function endHibachiLifecycle() {
 		if(getHibachiScope().getPersistSessionFlag()) {
@@ -729,15 +729,15 @@ component extends="FW1.framework" {
 		if(!getHibachiScope().getORMHasErrors()) {
 			getHibachiScope().getDAO("hibachiDAO").flushORMSession();
 		}
-		
+
 		// Commit audit queue
 		getHibachiScope().getService("hibachiAuditService").commitAudits();
 	}
-	
+
 	// Additional redirect function to redirect to an exact URL and flush the ORM Session when needed
 	public void function redirectExact(required string redirectLocation, boolean addToken=false) {
 		endHibachiLifecycle();
-		
+
 		if(!redirectLocation.startsWith('http')) {
 			location(arguments.redirectLocation, arguments.addToken);
 		} else {
@@ -745,7 +745,7 @@ component extends="FW1.framework" {
 			var redirectDomainApprovedFlag = false;
 			if (listLen( getHibachiScope().setting('globalAllowedOutsideRedirectSites') )){
 				allowedDomainArray = listToArray( getHibachiScope().setting('globalAllowedOutsideRedirectSites') );
-				
+
 				for (var allowedDomain in allowedDomainArray){
 					if ( LEFT(arguments.redirectLocation, len(allowedDomain)) == allowedDomain){
 						redirectDomainApprovedFlag = true;
@@ -753,8 +753,8 @@ component extends="FW1.framework" {
 					}
 				}
 			}
-			
-			// Check to make sure that the redirect stays on the Slatwall site, redirect back to the Slatwall landing page. 
+
+			// Check to make sure that the redirect stays on the Slatwall site, redirect back to the Slatwall landing page.
 			if ( getPageContext().getRequest().GetRequestUrl().toString() == LEFT(arguments.redirectLocation, len(getPageContext().getRequest().GetRequestUrl().toString())) || redirectDomainApprovedFlag == true ){
 				location(arguments.redirectLocation, arguments.addToken);
 			}else{
@@ -762,10 +762,10 @@ component extends="FW1.framework" {
 			}
 		}
 	}
-	
+
 	// This method will execute an actions controller, render the view for that action and return it without going through an entire lifecycle
 	public string function doAction(required string action, struct data) {
-		
+
 		var response = "";
 		var originalFW1 = {};
 		var originalContext = {};
@@ -773,50 +773,50 @@ component extends="FW1.framework" {
 		var originalBase = "";
 		var originalURLAction = "";
 		var originalFormAction = "";
-		
+
 		// If there was already a request._fw1, then we need to save it to be used later
 		if(structKeyExists(request, "_fw1")) {
 			originalFW1 = request._fw1;
 			structDelete(request, "_fw1");
 		}
-		
+
 		// If there was already a request.context, then we need to save it to be used later
 		if(structKeyExists(request, "context")) {
 			originalContext = request.context;
 			structDelete(request, "context");
 		}
-		
+
 		// We also need to store the original cfcbase if there was one
 		if(structKeyExists(request, "cfcbase")) {
 			originalCFCBase = request.cfcbase;
 			structDelete(request, "cfcbase");
 		}
-		
+
 		// We also need to store the original base if there was one
 		if(structKeyExists(request, "base")) {
 			originalBase = request.base;
 			structDelete(request, "base");
 		}
-		
+
 		// Look for an action in the URL
 		if( structKeyExists(url, getAction() ) ) {
 			originalURLAction = url[ getAction() ];
 		}
-		
+
 		// Look for an action in the Form
 		if( structKeyExists(form, getAction() ) ) {
 			originalFormAction = form[ getAction() ];
 		}
-		
+
 		// Set the passed in action to the form scope
 		form[ getAction() ] = arguments.action;
-		
+
 		// create a new request context to hold simple data, and an empty request services so that the view() function works
 		request.context = {};
 		if(!isnull(arguments.data)){
 			request.context = arguments.data;
 		}
-		
+
 		request._fw1 = {
 	        cgiScriptName = CGI.SCRIPT_NAME,
 	        cgiRequestMethod = CGI.REQUEST_METHOD,
@@ -825,55 +825,55 @@ component extends="FW1.framework" {
 	        services = [ ],
 	        trace = [ ]
 	    };
-	    
+
 		savecontent variable="response" {
 			onRequestStart('/index.cfm');
 			onRequest('/index.cfm');
-			onRequestEnd();	
+			onRequestEnd();
 		}
-		
+
 		// Remove the cfcbase & base from the request so that future actions don't get screwed up
 		structDelete( request, 'context' );
 		structDelete( request, '_fw1' );
 		structDelete( request, 'cfcbase' );
 		structDelete( request, 'base' );
-		
+
 		// If there was an override view action before... place it back into the request
 		if(structCount(originalContext)) {
 			request.context = originalContext;
 		}
-		
+
 		// If there was an override view action before... place it back into the request
 		if(structCount(originalFW1)) {
 			request._fw1 = originalFW1;
 		}
-		
+
 		// If there was a different cfcbase before... place it back into the request
 		if(len(originalCFCBase)) {
 			request.cfcbase = originalCFCBase;
 		}
-		
+
 		// If there was a different base before... place it back into the request
 		if(len(originalBase)) {
 			request.base = originalBase;
 		}
-		
+
 		if(len(originalURLAction)) {
 			url[ getAction() ] = originalURLAction;
 		}
-		
+
 		if(len(originalFormAction)) {
 			form[ getAction() ] = originalFormAction;
 		}
-		
+
 		return response;
 	}
-	
+
 	// @hint private helper method
 	public any function getHibachiScope() {
 		return request["#variables.framework.applicationKey#Scope"];
 	}
-	
+
 	// @hint setups an application scope value that will always be consistent
 	public any function getHibachiInstanceApplicationScopeKey() {
 		var metaData = getMetaData( this );
@@ -881,13 +881,13 @@ component extends="FW1.framework" {
 			var filePath = metaData.path;
 			metaData = metaData.extends;
 		} while( structKeyExists(metaData, "extends") );
-		
+
 		filePath = lcase(replaceNoCase(getDirectoryFromPath(replace(filePath,"\","/","all")), "/fw1/","/","all"));
 		var appKey = hash(filePath);
-		
+
 		return appKey;
 	}
-	
+
 	public void function onError(any exception, string event){
 		//if something fails for any reason then we want to set the response status so our javascript can handle rest errors
 		var context = getPageContext();
@@ -895,16 +895,16 @@ component extends="FW1.framework" {
 		response.setStatus(500);
 		super.onError(arguments.exception,arguments.event);
 	}
-	
+
 	// THESE METHODS ARE INTENTIONALLY LEFT BLANK
 	public void function onEveryRequest() {}
-	
+
 	public void function onInternalRequest() {}
-	
+
 	public void function onFirstRequest() {}
-	
+
 	public void function onUpdateRequest() {}
-	
+
 	public void function onFirstRequestPostUpdate() {}
-	
+
 }

--- a/org/Hibachi/HibachiSessionService.cfc
+++ b/org/Hibachi/HibachiSessionService.cfc
@@ -23,25 +23,25 @@ component output="false" accessors="true" extends="HibachiService"  {
 		config[ 'instantiationKey' ] = '#getApplicationValue('instantiationKey')#';
 		return config;
 	}
-	
+
 	public void function setPropperSession() {
 		var requestHeaders = getHTTPRequestData();
-		
+
 		// Check to see if a session value doesn't exist, then we can check for a cookie... or just set it to blank
 		if(!getHibachiScope().hasSessionValue("sessionID")) {
 			getHibachiScope().setSessionValue('sessionID', '');
 		}
 		var foundWithNPSID = false;
 		var foundWithPSID = false;
-		
+
 		// Check for non-persistent cookie.
 		if( len(getHibachiScope().getSessionValue('sessionID')) ) {
 			var sessionEntity = this.getSession( getHibachiScope().getSessionValue('sessionID'), true);
-		
+
 		} else if( (StructKeyExists(request,'context') && StructKeyExists(request.context, "jsonRequest") && request.context.jsonRequest && StructKeyExists(request.context.deserializedJsonData, "request_token") ) || StructKeyExists(requestHeaders.headers, "request_token") ){
 				//If the API 'cookie' and deviceID were passed directly to the API, we can use that for setting the session if the request token matches
 				//the token we already have.
-				
+
 				//Find the request token in the json or in the headers if it exists.
 				var rt = "";
 				if (StructKeyExists(request.context, "jsonRequest") && request.context.jsonRequest){
@@ -50,243 +50,228 @@ component output="false" accessors="true" extends="HibachiService"  {
 				if (StructKeyExists(requestHeaders.headers, "request_token")){
 					rt = requestHeaders.headers["request_token"];
 				}
-								
+
 				//set the session
 				var NPSID = rt;
 				var sessionEntity = this.getSessionBySessionCookieNPSID( NPSID, true );
 				foundWithNPSID = true;
 				getHibachiScope().setSessionValue('sessionID', sessionEntity.getSessionID());
 				request.context["foundWithRequestToken"] = true;
-				
-				/*
-				if ( StructKeyExists(request.context, "deviceID") && !Len(sessionEntity.getDeviceID())){
-					//If the device doesn't yet exist, add it.'
-					sessionEntity.setDeviceID("#request.context.deviceID#");
-					foundWithNPSID = true;
-					getHibachiScope().setSessionValue('sessionID', sessionEntity.getSessionID());
-				}else if (( StructKeyExists(requestHeaders.headers, "deviceID") && Len(sessionEntity.getDeviceID()) )){
-					//If the device already exists, check against that device to the new device id.
-					if (requestHeaders.headers.deviceID == sessionEntity.getDeviceID()){
-						foundWithNPSID = true;
-						getHibachiScope().setSessionValue('sessionID', sessionEntity.getSessionID()); //We have the correct device for this session.
-					}else{
-						//we don't have the correct device for this session so dont set the session
-						foundWithNPSID = false;
-					}
-				}
-				*/
-			
+
+
 		}else if(structKeyExists(cookie, "#getApplicationValue('applicationKey')#-NPSID")) {
 			var sessionEntity = this.getSessionBySessionCookieNPSID( cookie["#getApplicationValue('applicationKey')#-NPSID"], true);
-		
+
 			if(sessionEntity.getNewFlag()) {
 				getHibachiTagService().cfcookie(name="#getApplicationValue('applicationKey')#-NPSID", value='', expires="now");
 			} else {
-		
+
 				foundWithNPSID = true;
 				getHibachiScope().setSessionValue('sessionID', sessionEntity.getSessionID());
-		
+
 			}
-		
+
 		// Check for a persistent cookie.
 		} else if(structKeyExists(cookie, "#getApplicationValue('applicationKey')#-PSID")) {
-		
+
 			var sessionEntity = this.getSessionBySessionCookiePSID( cookie["#getApplicationValue('applicationKey')#-PSID"], true);
-		
+
 			if(sessionEntity.getNewFlag()) {
 				getHibachiTagService().cfcookie(name="#getApplicationValue('applicationKey')#-PSID", value='', expires="now");
 			} else {
 				foundWithPSID = true;
 				getHibachiScope().setSessionValue('sessionID', sessionEntity.getSessionID());
 			}
-		
-		
+
+
 		} else {
-			
+
 			var sessionEntity = this.newSession();
-		
+
 		}
-		
+
 		// Populate the hibachi scope with the session
 		getHibachiScope().setSession( sessionEntity );
 		// Let the hibachiScope know how we found the proper sessionID
 		getHibachiScope().setSessionFoundNPSIDCookieFlag( foundWithNPSID );
 		getHibachiScope().setSessionFoundPSIDCookieFlag( foundWithPSID );
-		
+
 		// Variable to store the last request dateTime of a session
 		var previousRequestDateTime = getHibachiScope().getSession().getLastRequestDateTime();
-		
+
 		// update the sessionScope with the ID for the next request
 		getHibachiScope().setSessionValue('sessionID', getHibachiScope().getSession().getSessionID());
-		
+
 		// Update the last request datetime, and IP Address
 		getHibachiScope().getSession().setLastRequestDateTime( now() );
 		getHibachiScope().getSession().setLastRequestIPAddress( CGI.REMOTE_ADDR );
-		
+
 		if(!isNull(getHibachiScope().getSession().getRBLocale())) {
 			getHibachiScope().setRBLocale( getHibachiScope().getSession().getRBLocale() );
-		
+
 		}
-		
+
 		// If the session has an account but no authentication, then remove the account
-		
+
 		// Check to see if this session has an accountAuthentication, if it does then we need to verify that the authentication shouldn't be auto logged out
-		
+
 		// If there was an integration, then check the verify method for any custom auto-logout logic
-		
-		// If the sessions account is and admin and last request by the session was 15 min or longer ago. 
-		
+
+		// If the sessions account is and admin and last request by the session was 15 min or longer ago.
+
 		if((getHibachiScope().getSessionFoundPSIDCookieFlag() && getHibachiScope().getLoggedInFlag())
-		
-			|| (!isNull(getHibachiScope().getSession().getAccountAuthentication()) && getHibachiScope().getSession().getAccountAuthentication().getForceLogoutFlag()) 
-		
+
+			|| (!isNull(getHibachiScope().getSession().getAccountAuthentication()) && getHibachiScope().getSession().getAccountAuthentication().getForceLogoutFlag())
+
 			|| (isNull(getHibachiScope().getSession().getAccountAuthentication()) && getHibachiScope().getLoggedInFlag())
-		
+
 			|| (!isNull(getHibachiScope().getSession().getAccountAuthentication()) && getHibachiScope().getSession().getAccount().getAdminAccountFlag() == true && DateDiff('n', previousRequestDateTime, Now()) >= getHibachiScope().setting('globalAdminAutoLogoutMinutes') )
-		
+
 			|| (!isNull(getHibachiScope().getSession().getAccountAuthentication()) && getHibachiScope().getSession().getAccount().getAdminAccountFlag() != true && DateDiff('n', previousRequestDateTime, Now()) >= getHibachiScope().setting('globalPublicAutoLogoutMinutes') )
-		
+
 		) 	{
-	
+
 		logoutAccount();
-	
+
 		}
-	
+
 	}
-	
+
 	public void function persistSession() {
-	
+
 		// Save the session
 		getHibachiDAO().save( getHibachiScope().getSession() );
-		
+
 		// Save session ID in the session Scope & cookie scope for next request
 		getHibachiScope().setSessionValue('sessionID', getHibachiScope().getSession().getSessionID());
-		
+
+		var domain = getApplicationValue("hibachiConfig").sessionCookieDomain;
+
 		//Generate new session cookies for every time the session is persisted (on every login)
 		var npCookieValue = getValueForCookie();
 			getHibachiScope().getSession().setSessionCookieNPSID(npCookieValue);
-			getHibachiTagService().cfcookie(name="#getApplicationValue('applicationKey')#-NPSID", value=getHibachiScope().getSession().getSessionCookieNPSID());
+			getHibachiTagService().cfcookie(name="#getApplicationValue('applicationKey')#-NPSID", value=getHibachiScope().getSession().getSessionCookieNPSID(), domain=domain);
 	    var cookieValue = getValueForCookie();
 			getHibachiScope().getSession().setSessionCookiePSID(cookieValue);
-			getHibachiTagService().cfcookie(name="#getApplicationValue('applicationKey')#-PSID", value=getHibachiScope().getSession().getSessionCookiePSID(), expires="never");
-		
+			getHibachiTagService().cfcookie(name="#getApplicationValue('applicationKey')#-PSID", value=getHibachiScope().getSession().getSessionCookiePSID(), expires="never", domain=domain);
+
 	}
-	
+
 	public string function loginAccount(required any account, required any accountAuthentication) {
-	
+
 		var currentSession = getHibachiScope().getSession();
 		currentSession.setAccount( arguments.account );
 		currentSession.setAccountAuthentication( arguments.accountAuthentication );
-	    
+
 		// Make sure that we persist the session
 		persistSession();
-	
+
 		// Make sure that this login is persisted
 		getHibachiDAO().flushORMSession();
-	
+
 		var auditLogData = {
-	
+
 			account = arguments.account
-	
+
 		};
-	
+
 		getHibachiAuditService().logAccountActivity( "login", auditLogData );
 		getHibachiEventService().announceEvent("onSessionAccountLogin");
-	
+
 	}
-	
+
 	public void function logoutAccount() {
 		var currentSession = getHibachiScope().getSession();
 		var auditLogData = {};
-	
+
 		if(!isNull(currentSession.getAccount())) {
 			auditLogData.account = currentSession.getAccount();
 		}
-	
+
 		currentSession.removeAccount();
 		currentSession.removeAccountAuthentication();
-	
+
 		// Make sure that this logout is persisted
 		getHibachiDAO().flushORMSession();
 		getHibachiAuditService().logAccountActivity("logout", auditLogData);
 		getHibachiEventService().announceEvent("onSessionAccountLogout");
 	}
-	
+
 	// =====================  END: Logical Methods ============================
-	
+
 	// ===================== START: DAO Passthrough ===========================
-	
+
 	// ===================== START: DAO Passthrough ===========================
-	
+
 	// ===================== START: Process Methods ===========================
-	
+
 	public any function processSession_authorizeAccount(required any session, required any processObject) {
-		
+
 		// Take the email address and get all of the user accounts by primary e-mail address
 		var accountAuthentications = getAccountService().getInternalAccountAuthenticationsByEmailAddress(emailAddress=arguments.processObject.getEmailAddress());
-	
+
 		if(arrayLen(accountAuthentications)) {
-			
+
 			for(var i=1; i<=arrayLen(accountAuthentications); i++) {
-				// If the password matches what it should be, then set the account in the session and 
-		
+				// If the password matches what it should be, then set the account in the session and
+
 				if(!isNull(accountAuthentications[i].getPassword()) && len(accountAuthentications[i].getPassword()) && accountAuthentications[i].getPassword() == getAccountService().getHashedAndSaltedPassword(password=arguments.processObject.getPassword(), salt=accountAuthentications[i].getAccountAuthenticationID())) {
 					loginAccount( accountAuthentications[i].getAccount(), accountAuthentications[i] );
 					return arguments.session;
 				}
-		
+
 			}
-	
+
 			arguments.processObject.addError('password', rbKey('validate.session_authorizeAccount.password.incorrect'));
-			
+
 		} else {
-			
+
 			arguments.processObject.addError('emailAddress', rbKey('validate.session_authorizeAccount.emailAddress.notfound'));
-			
+
 		}
-	
+
 		return arguments.session;
-	
+
 	}
-	
+
 	// =====================  END: Process Methods ============================
-	
+
 	// ====================== START: Status Methods ===========================
-	
+
 	// ======================  END: Status Methods ============================
-	
+
 	// ====================== START: Save Overrides ===========================
-	
+
 	// ======================  END: Save Overrides ============================
-	
+
 	// ==================== START: Smart List Overrides =======================
-	
+
 	// ====================  END: Smart List Overrides ========================
-	
+
 	// ====================== START: Get Overrides ============================
-	
+
 	// ======================  END: Get Overrides =============================
-	
+
 	// ===================== START: Delete Overrides ==========================
-	
+
 	// =====================  END: Delete Overrides ===========================
-	
+
 	// ================== START: Private Helper Functions =====================
-	
+
 	/**
 	* @deprecated getSessionIDEncryptedCookie
 	*/
 	private any function getSessionIDEncryptedCookie( required any sessionID, required string cookieType ) {
 		return getHibachiUtilityService().encryptValue(value=arguments.sessionID, salt="valid-#arguments.cookieType#-#getApplicationKey()#SessionIDCookie");
-	} 
-	
+	}
+
 	/*
 	* @deprecated getSessionIDFromEncryptedCookie
 	*/
 	private any function getSessionIDFromEncryptedCookie( required any cookieData, required string cookieType ) {
 		return getHibachiUtilityService().decryptValue(value=arguments.cookieData, salt="valid-#arguments.cookieType#-#getApplicationKey()#SessionIDCookie");
 	}
-	
+
 	/**
 	 * Generate new cookie value
 	 */
@@ -298,9 +283,9 @@ component output="false" accessors="true" extends="HibachiService"  {
 		return final;
 	}
 	// ==================  END:  Private Helper Functions =====================
-	
+
 	// =================== START: Deprecated Functions ========================
-	
+
 	// ===================  END: Deprecated Functions =========================
 
 }

--- a/org/Hibachi/HibachiTagService.cfc
+++ b/org/Hibachi/HibachiTagService.cfc
@@ -1,30 +1,31 @@
 <cfcomponent output="false" accessors="true" extends="HibachiService">
-	
+
 	<cffunction name="cfcookie">
 		<cfargument name="name" type="string" required="true" />
 		<cfargument name="value" type="any" required="true" />
 		<cfargument name="expires" type="string" />
 		<cfargument name="secure" type="boolean" default="false" />
-		
+		<cfargument name="domain" type="string" default="#CGI.HTTP_HOST#" />
+
 		<cfif structKeyExists(arguments, "expires")>
 			<cfcookie name="#arguments.name#" value="#arguments.value#" expires="#arguments.expires#" secure="#arguments.secure#" httponly="true">
 		<cfelse>
 			<cfcookie name="#arguments.name#" value="#arguments.value#" secure="#arguments.secure#" httponly="true">
 		</cfif>
 	</cffunction>
-	
+
 	<cffunction name="cfhtmlhead">
 		<cfargument name="text" type="string" required="true" />
 		<cfhtmlhead text="#arguments.text#">
 	</cffunction>
-	
+
 	<cffunction name="cfinvoke" output="false">
 		<cfargument name="component" type="any" required="true" hint="CFC name or instance." />
 		<cfargument name="method" type="string" required="true" hint="Method name to be invoked." />
 		<cfargument name="theArgumentCollection" type="struct" default="#structNew()#" hint="Argument collection to pass to method invocation." />
 
 		<cfset var returnVariable = 0 />
-		
+
 		<cfinvoke
 			component="#arguments.component#"
 			method="#arguments.method#"
@@ -35,16 +36,16 @@
 		<cfif not isNull( returnVariable )>
 			<cfreturn returnVariable />
 		</cfif>
-	
+
 	</cffunction>
-	
+
 	<cffunction name="cfmail" output="false">
 		<cfargument name="from" type="string" required="true" />
 		<cfargument name="to" type="string" required="true" />
 		<cfargument name="subject" default="" />
 		<cfargument name="body" default="" />
 		<cfargument name="type" default="html" />
-		
+
 		<cftry>
 			<cfmail attributeCollection="#arguments#">
 				#arguments.body#
@@ -55,7 +56,7 @@
 		</cftry>
 
 	</cffunction>
-	
+
 	<!--- The script version of http doesn't suppose tab delimiter, it throws error.
 		Use this method only when you want to return a query. --->
 	<cffunction name="cfhttp" output="false">
@@ -63,65 +64,65 @@
 		<cfargument name="url" default="" />
 		<cfargument name="delimiter" default="" />
 		<cfargument name="textqualifier" default="" />
-		
+
 		<cfhttp method="#arguments.method#" url="#arguments.url#" name="result" firstrowasheaders="true" textqualifier="#arguments.textqualifier#" delimiter="#arguments.delimiter#">
-		
+
 		<cfreturn result />
 	</cffunction>
-	
+
 	<cffunction name="cfsetting" output="false">
 		<cfargument name="enablecfoutputonly" type="boolean" default="false" />
 		<cfargument name="requesttimeout" type="numeric" default="30" />
 		<cfargument name="showdebugoutput" type="boolean" default="false" />
-		
+
 		<cfsetting attributecollection="#arguments#" />
 	</cffunction>
-	
+
 	<cffunction name="cffile" output="false">
 		<cfargument name="action" type="string" />
-		
+
 		<cfset var result = "" />
 		<cfset var attributes = duplicate(arguments) />
 		<cfset structDelete(attributes, "action") />
-		
+
 		<cffile attributecollection="#attributes#" action="#arguments.action#" result="result" >
-		
+
 		<cfreturn result />
 	</cffunction>
-	
+
 	<cffunction name="cfdirectory" output="false">
 		<cfargument name="action" type="string" />
-		
+
 		<cfset var result = "" />
 		<cfset var attributes = duplicate(arguments) />
 		<cfset structDelete(attributes, "action") />
-		
+
 		<cfdirectory attributecollection="#attributes#" action="#arguments.action#" name="result" >
-		
+
 		<cfreturn result />
 	</cffunction>
-	
+
 	<cffunction name="cfcontent" output="false">
 		<cfargument name="type" type="string" />
 		<cfargument name="file" type="string" />
 		<cfargument name="deletefile" type="boolean" default="false" />
-		
+
 		<cfcontent attributecollection="#arguments#"  />
 	</cffunction>
-	
+
 	<cffunction name="cfheader" output="false">
 		<cfargument name="name" type="string" />
 		<cfargument name="value" type="string" />
-		
+
 		<cfheader attributecollection="#arguments#"  />
 	</cffunction>
-	
+
 	<cffunction name="cfmodule">
 		<cfargument name="name" type="string" />
 		<cfargument name="template" type="string" />
 		<cfargument name="attributeCollection" type="struct" required="true" />
-		
-		<cfset var returnContent = "" /> 
+
+		<cfset var returnContent = "" />
 		<cfif structKeyExists(arguments, "name")>
 			<cfsavecontent variable="returnContent">
 				<cfmodule name="#arguments.name#" attributecollection="#arguments.attributeCollection#" />
@@ -131,7 +132,7 @@
 				<cfmodule template="#arguments.template#" attributecollection="#arguments.attributeCollection#" />
 			</cfsavecontent>
 		</cfif>
-		
+
 		<cfreturn returnContent />
 	</cffunction>
 </cfcomponent>

--- a/org/Hibachi/HibachiTagService.cfc
+++ b/org/Hibachi/HibachiTagService.cfc
@@ -8,9 +8,9 @@
 		<cfargument name="domain" type="string" default="#CGI.HTTP_HOST#" />
 
 		<cfif structKeyExists(arguments, "expires")>
-			<cfcookie name="#arguments.name#" value="#arguments.value#" expires="#arguments.expires#" secure="#arguments.secure#" httponly="true">
+			<cfcookie name="#arguments.name#" value="#arguments.value#" expires="#arguments.expires#" secure="#arguments.secure#" httponly="true" domain="#arguments.domain#">
 		<cfelse>
-			<cfcookie name="#arguments.name#" value="#arguments.value#" secure="#arguments.secure#" httponly="true">
+			<cfcookie name="#arguments.name#" value="#arguments.value#" secure="#arguments.secure#" httponly="true" domain="#arguments.domain#">
 		</cfif>
 	</cffunction>
 


### PR DESCRIPTION
This is important so that a site with multiple sub-domains can now set the following value in /custom/config/configFramework.cfm

```
variables.framework.hibachi.sessionCookieDomain = .mySite.com
```

This will allow for all sub-domains to use the same session for logins, etc.

Also cleaned up some misc formatting and commented out stuff.