### PR TITLE
change the check for account content access to account for multiple

### DIFF
--- a/model/service/OrderService.cfc
+++ b/model/service/OrderService.cfc
@@ -2255,11 +2255,11 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 			// If there was one or more accountContentAccess associated with the referenced orderItem then we need to remove them.
 			var accountContentAccessSmartList = getAccountService().getAccountContentAccessSmartList();
 			accountContentAccessSmartList.addFilter("OrderItem.orderItemID", stockReceiverItem.getOrderItem().getReferencedOrderItem().getOrderItemID());
-			accountContentAccesses = accountContentAccessSmartList.getRecords();
+			var accountContentAccesses = accountContentAccessSmartList.getRecords();
 			for (var accountContentAccess in accountContentAccesses){
-    			if(!isNull(accountContentAccess)) {
-    				getAccountService().deleteAccountContentAccess( accountContentAccess );
-    			}
+    			
+    			getAccountService().deleteAccountContentAccess( accountContentAccess );
+    			
 			}
 		}
 

--- a/model/service/OrderService.cfc
+++ b/model/service/OrderService.cfc
@@ -2252,13 +2252,16 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 				}
 			}
 
-			// If there was an accountContentAccess associated with the referenced orderItem then we need to remove it.
-			var accountContentAccess = getAccountService().getAccountContentAccess({orderItem=stockReceiverItem.getOrderItem().getReferencedOrderItem()});
-			if(!isNull(accountContentAccess)) {
-				getAccountService().deleteAccountContentAccess( accountContentAccess );
+			// If there was one or more accountContentAccess associated with the referenced orderItem then we need to remove them.
+			var accountContentAccessSmartList = getAccountService().getAccountContentAccessSmartList();
+			accountContentAccessSmartList.addFilter("OrderItem.orderItemID", stockReceiverItem.getOrderItem().getReferencedOrderItem().getOrderItemID());
+			accountContentAccesses = accountContentAccessSmartList.getRecords();
+			for (var accountContentAccess in accountContentAccesses){
+    			if(!isNull(accountContentAccess)) {
+    				getAccountService().deleteAccountContentAccess( accountContentAccess );
+    			}
 			}
 		}
-
 
 		stockReceiver = getStockService().saveStockReceiver( stockReceiver );
 


### PR DESCRIPTION
content access and delete them all. This is tested working on my local by creating a content access product. Ordering it. checking that accountContentAccess exist in the DB. Then returning it and verifying that they were all deleted.
I also checked that there were no other references to the getter getAccountContentAccess, and all other versions use the smartlist.