### PR TITLE
fixing select box initializations when conditionally hiding

### DIFF
--- a/org/Hibachi/HibachiAssets/js/global.js
+++ b/org/Hibachi/HibachiAssets/js/global.js
@@ -1015,7 +1015,7 @@ function setupEventHandlers() {
 	});
 
 	//Initiate SelectBoxIt on select boxes
-	// $("select.j-custom-select").selectBoxIt();
+	$("select.j-custom-select").selectBoxIt();
 
 	//Toggles the defualt toggle buttons
 	jQuery('body').on('click', '.s-btn-toggle', function(e){


### PR DESCRIPTION
I looked through the git history of both slatwall and hibachi to try and find out the reason why this line was commented out in the first place and couldn't. But this does solve issues of fields being hidden when they should be shown. 