### PR TITLE
adding null checking to getexportfilename in hibachireport

### DIFF
--- a/org/Hibachi/HibachiReport.cfc
+++ b/org/Hibachi/HibachiReport.cfc
@@ -1150,7 +1150,7 @@
 
 		<!--- Create the filename variables --->
 		<cfset var filename = "" />
-		<cfif not isNull(getReportEntity())>
+		<cfif !isNull(getReportEntity()) && !isNull(getReportEntity().getReportTitle()) >
 			<cfset filename = getService("HibachiUtilityService").createSEOString(getReportEntity().getReportTitle()) />
 			<cfset filename &= "_" />
 		<cfelse>


### PR DESCRIPTION
prevents errors for titleless reports

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4417)
<!-- Reviewable:end -->
