### PR TITLE
Hotfix yy replacestringtemplatetest

### DIFF
--- a/meta/tests/unit/service/HibachiUtilityServiceTest.cfc
+++ b/meta/tests/unit/service/HibachiUtilityServiceTest.cfc
@@ -54,6 +54,14 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 		variables.service = request.slatwallScope.getService("hibachiUtilityService");
 	}
 	
+	public void function replaceStringTemplateTest(){
+		var mockTemplate = '<div>${anything}</div>${anothertemplateKey},${onemoretemplatekey}';
+		var mockStructure = {
+			anything='value',
+			anothertemplateKey="othervalue"
+		};
+		
+	}
 	
 	public void function lcaseStructKeys_lcases_structure_keys_at_top_level() {
 		var data = {};

--- a/meta/tests/unit/service/HibachiUtilityServiceTest.cfc
+++ b/meta/tests/unit/service/HibachiUtilityServiceTest.cfc
@@ -53,15 +53,81 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 		
 		variables.service = request.slatwallScope.getService("hibachiUtilityService");
 	}
+			
+	public void function getTemplateKeysTest() {
+		var mockTemplate = '<div>${anything}</div>${anotherTemplateKey},${onemoreTemplateKey}';
+		
+		var expectedTemplateKeyValues = [
+			'${anything}',
+			'${anotherTemplateKey}',
+			'${onemoreTemplateKey}'
+		];
+		
+		var resultTemplateKeys = variables.service.getTemplateKeys(mockTemplate);
+		
+		assertEquals(resultTemplateKeys,expectedTemplateKeyValues);
+		
+		/*
+		mockStructure.onemoreTemplateKey = variables.service.getTemplateKeys(mockStructure.onemoreTemplateKey);
+//		request.debug(serializejson(mockStructure));
+//		assertEquals(serializejson(mockStructure), serializejson(testStructure));
+		assertEquals(mockStructure.onemoreTemplateKey, testStructure.onemoreTemplateKey);
+		*/
+	}
 	
-	public void function replaceStringTemplateTest(){
-		var mockTemplate = '<div>${anything}</div>${anothertemplateKey},${onemoretemplatekey}';
+	public void function replaceStringTemplate_withStructure_Test(){
+		//testing with a structure
+		var mockTemplate = '<div>${anything}</div>${anotherTemplateKey},${onemoreTemplateKey}';
+		
 		var mockStructure = {
-			anything='value',
-			anothertemplateKey="othervalue"
-		};
+			anything = 'value',
+			anotherTemplateKey = "othervalue",
+			onemoreTemplateKey = "onemorevalue"
+		}; 
+		var resultStringResult = variables.service.replaceStringTemplate(mockTemplate, mockStructure);
+		assertEquals(resultStringResult,'<div>value</div>othervalue,onemorevalue');
+	}
+	
+	public void function replaceStringTemplate_withObject_Test(){
+		//testing with an object
+		var mockTemplate = '<div>${firstName}</div>';
+		
+		var mockObject = createTestEntity('Account');
+		mockObject.setFirstName('Yuqing');
+		
+		var resultStringResult = variables.service.replaceStringTemplate(mockTemplate, mockObject);
+		
+		assertEquals(resultStringResult,'<div>Yuqing</div>');
+	}
+	
+	public void function replaceStringTemplate_withObjectMissingKey_Test(){
+		//testing Missing Object
+		var mockTemplate = '<div>${firstName}</div>';
+		var mockObject = createTestEntity('Account');
+		
+		var resultMissingObject = variables.service.replaceStringTemplate(mockTemplate, mockObject);
+		assertEquals(resultMissingObject,'<div></div>');
 		
 	}
+	
+	public void function replaceStringTemplate_withStructureMissingKey_Test(){
+		//testing Missing Structure
+		var mockTemplate = '<div>${anything}</div>${anotherTemplateKey},${onemoreTemplateKey}';
+		var mockStructure = {
+		}; 
+		var resultMissingStructure = variables.service.replaceStringTemplate(mockTemplate, mockStructure);
+		assertEquals(resultMissingStructure, '<div>${anything}</div>${anotherTemplateKey},${onemoreTemplateKey}');
+	}
+	
+	public void function replaceStringTemplate_withStructureMissingKeyRemoveMissingKey_Test(){
+		//testing Missing Structure
+		var mockTemplate = '<div>${anything}</div>${anotherTemplateKey},${onemoreTemplateKey}';
+		var mockStructure = {}; 
+		var resultMissingStructure = variables.service.replaceStringTemplate(mockTemplate, mockStructure,false,true);
+		assertEquals(resultMissingStructure, '<div></div>,');
+	}
+	
+	
 	
 	public void function lcaseStructKeys_lcases_structure_keys_at_top_level() {
 		var data = {};

--- a/meta/tests/unit/service/HibachiUtilityServiceTest.cfc
+++ b/meta/tests/unit/service/HibachiUtilityServiceTest.cfc
@@ -66,19 +66,38 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 		var resultTemplateKeys = variables.service.getTemplateKeys(mockTemplate);
 		
 		assertEquals(resultTemplateKeys,expectedTemplateKeyValues);
-		
-		/*
-		mockStructure.onemoreTemplateKey = variables.service.getTemplateKeys(mockStructure.onemoreTemplateKey);
-//		request.debug(serializejson(mockStructure));
-//		assertEquals(serializejson(mockStructure), serializejson(testStructure));
-		assertEquals(mockStructure.onemoreTemplateKey, testStructure.onemoreTemplateKey);
-		*/
 	}
+	
+	
+	public void function replaceStringTemplate_withObject_Test(){
+		//testing with an object
+		var mockTemplate = '<div>${firstName}</div>';
+		var mockObject = createTestEntity('Account');
+		mockObject.setFirstName('Yuqing');
+		var resultStringResult = variables.service.replaceStringTemplate(mockTemplate, mockObject);
+		assertEquals(resultStringResult,'<div>Yuqing</div>');
+	}
+	
+	public void function replaceStringTemplate_withObjectMissingKey_Test(){
+		//testing Missing Object
+		var mockTemplate = '<div>${firstName}</div>';
+		var mockObject = createTestEntity('Account');
+		var resultMissingObject = variables.service.replaceStringTemplate(mockTemplate, mockObject);
+		assertEquals(resultMissingObject,'<div></div>');
+		
+	}
+	public void function replaceStringTemplate_withObjectMissingKeyRemoveMissingKey_Test(){
+		//testing Missing Object with RemoveMissingKey True
+		var mockTemplate = '<div>${anything}</div>${anotherTemplateKey},${onemoreTemplateKey}';
+		var mockObject = {}; 
+		var resultMissingObject = variables.service.replaceStringTemplate(mockTemplate, mockObject,false,true);
+		assertEquals(resultMissingObject, '<div></div>,');
+	}
+	
 	
 	public void function replaceStringTemplate_withStructure_Test(){
 		//testing with a structure
 		var mockTemplate = '<div>${anything}</div>${anotherTemplateKey},${onemoreTemplateKey}';
-		
 		var mockStructure = {
 			anything = 'value',
 			anotherTemplateKey = "othervalue",
@@ -88,45 +107,21 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 		assertEquals(resultStringResult,'<div>value</div>othervalue,onemorevalue');
 	}
 	
-	public void function replaceStringTemplate_withObject_Test(){
-		//testing with an object
-		var mockTemplate = '<div>${firstName}</div>';
-		
-		var mockObject = createTestEntity('Account');
-		mockObject.setFirstName('Yuqing');
-		
-		var resultStringResult = variables.service.replaceStringTemplate(mockTemplate, mockObject);
-		
-		assertEquals(resultStringResult,'<div>Yuqing</div>');
-	}
-	
-	public void function replaceStringTemplate_withObjectMissingKey_Test(){
-		//testing Missing Object
-		var mockTemplate = '<div>${firstName}</div>';
-		var mockObject = createTestEntity('Account');
-		
-		var resultMissingObject = variables.service.replaceStringTemplate(mockTemplate, mockObject);
-		assertEquals(resultMissingObject,'<div></div>');
-		
-	}
-	
 	public void function replaceStringTemplate_withStructureMissingKey_Test(){
 		//testing Missing Structure
 		var mockTemplate = '<div>${anything}</div>${anotherTemplateKey},${onemoreTemplateKey}';
-		var mockStructure = {
-		}; 
+		var mockStructure = {}; 
 		var resultMissingStructure = variables.service.replaceStringTemplate(mockTemplate, mockStructure);
 		assertEquals(resultMissingStructure, '<div>${anything}</div>${anotherTemplateKey},${onemoreTemplateKey}');
 	}
 	
 	public void function replaceStringTemplate_withStructureMissingKeyRemoveMissingKey_Test(){
-		//testing Missing Structure
+		//testing Missing Structure with RemoveMissingKey True
 		var mockTemplate = '<div>${anything}</div>${anotherTemplateKey},${onemoreTemplateKey}';
 		var mockStructure = {}; 
 		var resultMissingStructure = variables.service.replaceStringTemplate(mockTemplate, mockStructure,false,true);
 		assertEquals(resultMissingStructure, '<div></div>,');
 	}
-	
 	
 	
 	public void function lcaseStructKeys_lcases_structure_keys_at_top_level() {

--- a/org/Hibachi/HibachiUtilityService.cfc
+++ b/org/Hibachi/HibachiUtilityService.cfc
@@ -293,12 +293,12 @@
 		}
 		
 		public array function getTemplateKeys(required string template){
-			returnreMatchNoCase("\${[^}]+}",arguments.template)
+			return reMatchNoCase("\${[^}]+}",arguments.template);
 		}
 		
 		//replace single brackets ${}
 		public string function replaceStringTemplate(required string template, required any object, boolean formatValues=false, boolean removeMissingKeys=false) {
-			var templateKeys = getTemplateKeys(arguments.templateKeys);
+			var templateKeys = getTemplateKeys(arguments.template);
 			var replacementArray = [];
 			var returnString = arguments.template;
 			for(var i=1; i<=arrayLen(templateKeys); i++) {
@@ -310,6 +310,7 @@
 				if( isStruct(arguments.object) && structKeyExists(arguments.object, valueKey) ) {
 					replaceDetails.value = arguments.object[ valueKey ];
 				} else if (isObject(arguments.object)) {
+					//if null then is blank
 					replaceDetails.value = arguments.object.getValueByPropertyIdentifier(valueKey, arguments.formatValues);
 				} else if (arguments.removeMissingKeys) {
 					replaceDetails.value = '';
@@ -320,7 +321,10 @@
 			for(var i=1; i<=arrayLen(replacementArray); i++) {
 				returnString = replace(returnString, replacementArray[i].key, replacementArray[i].value, "all");
 			}
-			if(arraylen(reMatchNoCase("\${[^}]+}",returnString))){
+			if(
+				arguments.template != returnString
+				&& arraylen(getTemplateKeys(returnString))
+			){
 				returnString = replaceStringTemplate(returnString, arguments.object, arguments.formatValues,arguments.removeMissingKeys);
 			}
 

--- a/org/Hibachi/HibachiUtilityService.cfc
+++ b/org/Hibachi/HibachiUtilityService.cfc
@@ -291,9 +291,14 @@
 
 			return returnString;
 		}
+		
+		public array function getTemplateKeys(required string template){
+			returnreMatchNoCase("\${[^}]+}",arguments.template)
+		}
+		
 		//replace single brackets ${}
 		public string function replaceStringTemplate(required string template, required any object, boolean formatValues=false, boolean removeMissingKeys=false) {
-			var templateKeys = reMatchNoCase("\${[^}]+}",arguments.template);
+			var templateKeys = getTemplateKeys(arguments.templateKeys);
 			var replacementArray = [];
 			var returnString = arguments.template;
 			for(var i=1; i<=arrayLen(templateKeys); i++) {


### PR DESCRIPTION
6 test cases added on HibachiUtilityServiceTest.cfc to test one function in HibacheUtilityService: replaceStringTemplate (//replace single brackets ${}) Two bugs:
1:  (Not fixed) Structure with no keys. The IF-ELSEIF-ELSEIF doesn't cover all circumstances
2: (Fixed) Endless loop of arguments.template

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4441)
<!-- Reviewable:end -->
