### PR TITLE
added extends hibachi to ajax controller

### DIFF
--- a/public/controllers/ajax.cfc
+++ b/public/controllers/ajax.cfc
@@ -46,7 +46,7 @@
 Notes:
 
 */
-component output="false" accessors="true" {
+component output="false" accessors="true" extends="Slatwall.org.Hibachi.HibachiController"{
 
 	property name="fw" type="any";
 


### PR DESCRIPTION
This was refactored to use getHibachiScope but doesn't have access to hibachi without.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4489)
<!-- Reviewable:end -->
