### PR TITLE
bug fix for ckeditor wysiwyg js needing to be loaded for modals

### DIFF
--- a/admin/layouts/default.cfm
+++ b/admin/layouts/default.cfm
@@ -362,7 +362,10 @@ Notes:
 			</span>
 		</span>
 		
-		<cfif structKeyExists(request,'isWysiwygPage') AND request.isWysiwygPage>
+		<cfif 	
+			(structKeyExists(request,'isWysiwygPage') AND request.isWysiwygPage)
+			|| (structKeyExists(rc,'edit') AND rc.edit eq true)	
+		>
 			<script type="text/javascript" src="#request.slatwallScope.getBaseURL()#/org/Hibachi/ckeditor/ckeditor.js"></script>
 			<script type="text/javascript" src="#request.slatwallScope.getBaseURL()#/org/Hibachi/ckeditor/adapters/jquery.js"></script>
 			<script type="text/javascript" src="#request.slatwallScope.getBaseURL()#/org/Hibachi/ckfinder/ckfinder.js"></script>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4491)
<!-- Reviewable:end -->
