### PR TITLE
fixes an issue with order service.

### DIFF
--- a/model/service/OrderService.cfc
+++ b/model/service/OrderService.cfc
@@ -308,9 +308,8 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 			// Check for the sku in the orderFulfillment already, so long that the order doens't have any errors
 			if(!arguments.order.hasErrors()) {
 				for(var orderItem in orderFulfillment.getOrderFulfillmentItems()){
-					// If the sku, price, attributes & stock all match then just increase the quantity
-
-					if(arguments.processObject.matchesOrderItem( orderItem )){
+					// If the sku, price, attributes & stock all match then just increase the quantity if and only if the match parent orderitem is null.
+					if(arguments.processObject.matchesOrderItem( orderItem ) && isNull(orderItem.getParentOrderItem())){
 						foundItem = true;
 						var foundOrderItem = orderItem;
 						orderItem.setQuantity(orderItem.getQuantity() + arguments.processObject.getQuantity());


### PR DESCRIPTION
To recreate, build a product bundle that has sku a and sku b. Add that product bundle to an order. Now try to add more of just sku a or just sku b. What happens is that it
increases the quantity of the matching child order item instead of just
adding a new sku. The price for the bundle then goes way out of whack.
This fixes that. This was implemented on buddies and it fixed the pricing issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4493)
<!-- Reviewable:end -->
