### PR TITLE
Update OrderService

### DIFF
--- a/model/service/OrderService.cfc
+++ b/model/service/OrderService.cfc
@@ -1426,7 +1426,7 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 
 		// As long as the amount received for this orderFulfillment is within the treshold of the auto fulfillment setting
 		if(
-			arguments.orderFulfillment.isAutoFulfillmentReadyToBeFulfilled()
+			arguments.orderFulfillment.getIsAutoFulfillmentReadyToBeFulfilled()
 		){
 
 			// Setup the processData


### PR DESCRIPTION
Fixes a hard error after update when using money order. The only thing not clear to me here is this...

Does a non-persistent property, have to have an associated method? Put another way, does using 'accesors=true' work on non-persistent properties as well? I ask because it seems like we always define a method when defining a non-persistent property but I had assumed that the normal getXXX/setXXX would work for non-persistent properties as well. In which case a method will also have to be added for this and another non-persistent property in orderFulfillment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4540)
<!-- Reviewable:end -->
