### PR TITLE
Fix the bug: will return undefined if no BRANDNAME in BRAND entity

### DIFF
--- a/model/entity/Product.cfc
+++ b/model/entity/Product.cfc
@@ -775,13 +775,13 @@ component displayname="Product" entityname="SlatwallProduct" table="SwProduct" p
 	public string function getBrandName() {
 		if(!structKeyExists(variables, "brandName")) {
 			variables.brandName = "";
-			if( structKeyExists(variables, "brand") ) {
+			if( structKeyExists(variables, "brand") && !isNull(getBrand().getBrandName())) {
 				return getBrand().getBrandName();
 			}
 		}
 		return variables.brandName;
 	}
-
+	
 	public array function getBrandOptions() {
 		var options = getPropertyOptions( "brand" );
 		options[1]['name'] = rbKey('define.none');


### PR DESCRIPTION
Fix the bug: will return undefined if BRAND entity does not have BRANDNAME property
So right now, the function will return empty string in two conditions: 
* No brand entity
* Has brand entity but no brandName

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4549)
<!-- Reviewable:end -->
