### PR TITLE
Delete the function getTemplateOptions() as it never been used.

### DIFF
--- a/model/entity/Product.cfc
+++ b/model/entity/Product.cfc
@@ -244,13 +244,6 @@ component displayname="Product" entityname="SlatwallProduct" table="SwProduct" p
 		}
 	}
 
-	public any function getTemplateOptions() {
-		if(!isDefined("variables.templateOptions")){
-			variables.templateOptions = getService("ProductService").getProductTemplates();
-		}
-		return variables.templateOptions;
-	}
-
 	public any function getImages() {
 		return variables.productImages;
 	}


### PR DESCRIPTION
As the title said, delete the function, and getProductTemplates() in ProductService.cfc is undefined, neither onMissing functions has related keyword

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4586)
<!-- Reviewable:end -->
