### PR TITLE
Hotfix yy product cfc delete two unused function: getOptionTemplates() and getPageIDs()

### DIFF
--- a/model/entity/Product.cfc
+++ b/model/entity/Product.cfc
@@ -244,13 +244,6 @@ component displayname="Product" entityname="SlatwallProduct" table="SwProduct" p
 		}
 	}
 
-	public any function getTemplateOptions() {
-		if(!isDefined("variables.templateOptions")){
-			variables.templateOptions = getService("ProductService").getProductTemplates();
-		}
-		return variables.templateOptions;
-	}
-
 	public any function getImages() {
 		return variables.productImages;
 	}

--- a/model/entity/Product.cfc
+++ b/model/entity/Product.cfc
@@ -270,14 +270,6 @@ component displayname="Product" entityname="SlatwallProduct" table="SwProduct" p
  		return arrayLen(getSkus()) eq 1 || getOptionGroupCount() gt 0;
  	}
 
-	public string function getPageIDs() {
-		var pageIDs = "";
-		for( var i=1; i<= arrayLen(getPages()); i++ ) {
-			pageIDs = listAppend(pageIDs,getPages()[i].getPageID());
-		}
-		return pageIDs;
-	}
-
 	public string function getCategoryIDs() {
 		var categoryIDs = "";
 		for( var i=1; i<= arrayLen(getCategories()); i++ ) {


### PR DESCRIPTION
Delete the two never used functions: getOptionTemplates() and getPageIDs()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4605)
<!-- Reviewable:end -->
