### PR TITLE
Add a function to check the 'type' used in persisted and non-cfc property

### DIFF
--- a/meta/tests/unit/core/EntityFormatTest.cfc
+++ b/meta/tests/unit/core/EntityFormatTest.cfc
@@ -434,17 +434,17 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 			var properties = request.slatwallScope.getService("hibachiService").getPropertiesByEntityName(entityName);
 			for(var property in properties) {
 				if (
-						(
+						/*(
 							!structKeyExists(property,'persistent')
 							 ||(
 							 	structKeyExists(property,'persistent') 
-							 	&& lcase(property.persistent) eq "true"
+							 	&& property.persistent
 							   )
 						)
-						&&!structKeyExists(property, "cfc") 
+						&&*/ !structKeyExists(property, "cfc") 
 						&& structKeyExists(property, "type") 
 				   ) {
-					criminalsMessage &= "entityName=#entityName# propertyName=#property.name#, <br>";
+					criminalsMessage &= "entityName=#entityName# propertyName=#property.name#, <br>"&chr(10)&chr(13);
 				}
 			}			
 		}

--- a/meta/tests/unit/core/EntityFormatTest.cfc
+++ b/meta/tests/unit/core/EntityFormatTest.cfc
@@ -424,8 +424,8 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 		
 	}
 	
-	//This function checks if the type instead of ormtype are used in properties that related with cfc entity
-	public void function check_cfc_related_properties_that_uses_type() {
+	//This function checks if a persistant property (not cfc) uses type instead of ormtype to define the datatype
+	public void function check_persistant_nonCFC_properties_that_use_type() {
 		var allEntities = listToArray(structKeyList(ORMGetSessionFactory().getAllClassMetadata()));
 		
 		var criminalsMessage = "";

--- a/meta/tests/unit/core/EntityFormatTest.cfc
+++ b/meta/tests/unit/core/EntityFormatTest.cfc
@@ -444,7 +444,7 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 						&& !structKeyExists(property, "cfc") 
 						&& structKeyExists(property, "type") 
 				   ) {
-					criminalsMessage &= "entityName=#entityName# propertyName=#property.name#, <br>"&chr(10)&chr(13);
+					criminalsMessage &= "entityName=#entityName# propertyName=#property.name# #property.type#, <br>"&chr(10)&chr(13);
 				}
 			}			
 		}

--- a/meta/tests/unit/core/EntityFormatTest.cfc
+++ b/meta/tests/unit/core/EntityFormatTest.cfc
@@ -401,7 +401,6 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 		var criminalsMessage = "";
 
 		for(var entityName in allEntities) {
-
 			var properties = request.slatwallScope.getService("hibachiService").getPropertiesByEntityName(entityName);
 			for(var property in properties) {
 				
@@ -411,11 +410,11 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 					&& structKeyExists(property, "cascade") 
 					&& findNoCase('delete', property.cascade)
 					&& !structKeyExists(property,'allowcascade')
-				) {
-					criminalsMessage &= "entityName=#entityName# propertyName=#property.name#, ";
-				}
-								
-			}
+				   ) {
+					criminalsMessage &= "entityName=#entityName# propertyName=#property.name#, <br>";
+				}	
+							
+			}			
 		}
 		
 		assert(
@@ -423,6 +422,36 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 			criminalsMessage
 		);
 		
+	}
+	
+	//This function checks if the type instead of ormtype are used in properties that related with cfc entity
+	public void function check_cfc_related_properties_that_uses_type() {
+		var allEntities = listToArray(structKeyList(ORMGetSessionFactory().getAllClassMetadata()));
+		
+		var criminalsMessage = "";
+
+		for(var entityName in allEntities) {
+			var properties = request.slatwallScope.getService("hibachiService").getPropertiesByEntityName(entityName);
+			for(var property in properties) {
+				if (
+					!structKeyExists(property, "cfc") 
+					&& structKeyExists(property, "type") 
+					&& (
+							!structKeyExists(property,'Persistent')
+							||(
+								structKeyExists(property,'Persistent')
+								&& property.persistent == True
+							  )
+					   )
+				   ) {
+					criminalsMessage &= "entityName=#entityName# propertyName=#property.name#, <br>";
+				}
+			}			
+		}
+		assert(
+			len(criminalsMessage) == 0,
+			criminalsMessage
+		);
 	}
 
 }

--- a/meta/tests/unit/core/EntityFormatTest.cfc
+++ b/meta/tests/unit/core/EntityFormatTest.cfc
@@ -443,6 +443,7 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 						)
 						&& !structKeyExists(property, "cfc") 
 						&& structKeyExists(property, "type") 
+						&& property.type != 'any'
 				   ) {
 					criminalsMessage &= "entityName=#entityName# propertyName=#property.name# #property.type#, <br>"&chr(10)&chr(13);
 				}

--- a/meta/tests/unit/core/EntityFormatTest.cfc
+++ b/meta/tests/unit/core/EntityFormatTest.cfc
@@ -434,14 +434,14 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 			var properties = request.slatwallScope.getService("hibachiService").getPropertiesByEntityName(entityName);
 			for(var property in properties) {
 				if (
-						/*(
+						(
 							!structKeyExists(property,'persistent')
 							 ||(
 							 	structKeyExists(property,'persistent') 
 							 	&& property.persistent
 							   )
 						)
-						&&*/ !structKeyExists(property, "cfc") 
+						&& !structKeyExists(property, "cfc") 
 						&& structKeyExists(property, "type") 
 				   ) {
 					criminalsMessage &= "entityName=#entityName# propertyName=#property.name#, <br>"&chr(10)&chr(13);

--- a/meta/tests/unit/core/EntityFormatTest.cfc
+++ b/meta/tests/unit/core/EntityFormatTest.cfc
@@ -434,15 +434,15 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 			var properties = request.slatwallScope.getService("hibachiService").getPropertiesByEntityName(entityName);
 			for(var property in properties) {
 				if (
-					!structKeyExists(property, "cfc") 
-					&& structKeyExists(property, "type") 
-					&& (
-							!structKeyExists(property,'Persistent')
-							||(
-								structKeyExists(property,'Persistent')
-								&& property.persistent == True
-							  )
-					   )
+						(
+							!structKeyExists(property,'persistent')
+							 ||(
+							 	structKeyExists(property,'persistent') 
+							 	&& lcase(property.persistent) eq "true"
+							   )
+						)
+						&&!structKeyExists(property, "cfc") 
+						&& structKeyExists(property, "type") 
 				   ) {
 					criminalsMessage &= "entityName=#entityName# propertyName=#property.name#, <br>";
 				}

--- a/model/entity/AccountPhoneNumber.cfc
+++ b/model/entity/AccountPhoneNumber.cfc
@@ -50,7 +50,7 @@ component displayname="Account Phone Number" entityname="SlatwallAccountPhoneNum
 	
 	// Persistent Properties
 	property name="accountPhoneNumberID" ormtype="string" length="32" fieldtype="id" generator="uuid" unsavedvalue="" default="";
-	property name="phoneNumber" hb_populateEnabled="public" type="string";
+	property name="phoneNumber" hb_populateEnabled="public" ormtype="string";
 	
 	// Related Object Properties (Many-To-One)
 	property name="account" cfc="Account" fieldtype="many-to-one" fkcolumn="accountID";


### PR DESCRIPTION
If a property that is persistent and not cfc-related, the type of data should be 'ormtype', not 'type'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4666)
<!-- Reviewable:end -->
