### PR TITLE
Update Shipping Service

### DIFF
--- a/model/service/ShippingService.cfc
+++ b/model/service/ShippingService.cfc
@@ -377,8 +377,8 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 			}
 		}
 
-		// Now if there is no method yet selected, and at least one shippingMethod as an option, we can automatically just select it.
-		if(isNull(arguments.orderFulfillment.getShippingMethod()) && arrayLen(arguments.orderFulfillment.getFulfillmentShippingMethodOptions()) >= 1) {
+		// Now if there is no method yet selected, and one shippingMethod exists as an option, we can automatically just select it.
+		if(isNull(arguments.orderFulfillment.getShippingMethod()) && arrayLen(arguments.orderFulfillment.getFulfillmentShippingMethodOptions()) == 1) {
 
 			// Set the method
 			arguments.orderFulfillment.setShippingMethod( arguments.orderFulfillment.getFulfillmentShippingMethodOptions()[1].getShippingMethodRate().getShippingMethod() );


### PR DESCRIPTION
This adds some checks to make sure that the shipping method options that are being added are allowed to be added. Previously, it was adding both manual and worldwide shipping methods to the fulfillment that it should not have been. Also, I updated the condition that decides when a new shipping method rate should be selected by default. Before, it would auto select if one and only one was available. I changed it to auto select the first one if at least one is available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4698)
<!-- Reviewable:end -->
