### PR TITLE
Fix to prevent hard error in mura

### DIFF
--- a/integrationServices/mura/model/handler/MuraEventHandler.cfc
+++ b/integrationServices/mura/model/handler/MuraEventHandler.cfc
@@ -695,9 +695,11 @@
 				
 				// Login Slatwall Account
 				var account = $.slatwall.getService("accountService").getAccountByCMSAccountID($.currentUser('userID'));
-				var accountAuth = ormExecuteQuery("SELECT aa FROM SlatwallAccountAuthentication aa WHERE aa.integration.integrationID = ? AND aa.account.accountID = ?", [getMuraIntegrationID(), account.getAccountID()]);
-				if (!isNull(account) && arrayLen(accountAuth)) {
-					$.slatwall.getService("hibachiSessionService").loginAccount(account=account, accountAuthentication=accountAuth[1]);
+				if (!isNull(account) ) {
+					var accountAuth = ormExecuteQuery("SELECT aa FROM SlatwallAccountAuthentication aa WHERE aa.integration.integrationID = ? AND aa.account.accountID = ?", [getMuraIntegrationID(), account.getAccountID()]);
+					if (arrayLen(accountAuth)) {
+						$.slatwall.getService("hibachiSessionService").loginAccount(account=account, accountAuthentication=accountAuth[1]);
+					}
 				}
 				
 			} else if ( $.slatwall.getLoggedInFlag()


### PR DESCRIPTION
This just prevents a hard error on every request if the logged in mura account doesn't exist in Slatwall

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4846)
<!-- Reviewable:end -->
