### PR TITLE
Prevent exclusion of NULLs when filtering using <>, !=, NOT IN or NOT LIKE

### DIFF
--- a/model/entity/Collection.cfc
+++ b/model/entity/Collection.cfc
@@ -717,7 +717,11 @@ component displayname="Collection" entityname="SlatwallCollection" table="SwColl
 
 					var predicate = getPredicate(filter);
 					if(isnull(filter.attributeID)){
-						filterGroupHQL &= " #logicalOperator# #filter.propertyIdentifier# #comparisonOperator# #predicate# ";
+						var propertyIdentifier = filter.propertyIdentifier;
+						if(ListFind('<>,!=,NOT IN,NOT LIKE',comparisonOperator) > 0){
+							propertyIdentifier = "COALESCE(#propertyIdentifier#,'')";
+						}
+						filterGroupHQL &= " #logicalOperator# #propertyIdentifier# #comparisonOperator# #predicate# ";
 					}else{
 						var attributeHQL = getFilterAttributeHQL(filter);
 						filterGroupHQL &= " #logicalOperator# #attributeHQL# #comparisonOperator# #predicate# ";


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4848)
<!-- Reviewable:end -->
