### PR TITLE
Fix nonexistent order item removal

### DIFF
--- a/model/service/OrderService.cfc
+++ b/model/service/OrderService.cfc
@@ -1490,7 +1490,7 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 			for(var n = ArrayLen(orderItemsToRemove); n >=1; n--)	{
 				var orderItem = this.getOrderItem(orderItemsToRemove[n]);
 				// Check to see if this item is the same ID as the one passed in to remove
-				if(arrayFindNoCase(orderItemsToRemove, orderItem.getOrderItemID())) {
+				if(!isNull(orderItem) && arrayFindNoCase(orderItemsToRemove, orderItem.getOrderItemID())) {
 
 					var okToRemove = true;
 


### PR DESCRIPTION
Calling "public:cart.removeOrderItem" with an orderItemID that doesn't exist in cart throws an error - "variable [orderItem] doesn't exist".

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4880)

<!-- Reviewable:end -->
