### PR TITLE
pull bindings was heavy handed and pulling unneccarily for bindings that

### DIFF
--- a/model/entity/WorkflowTrigger.cfc
+++ b/model/entity/WorkflowTrigger.cfc
@@ -124,7 +124,10 @@ component entityname="SlatwallWorkflowTrigger" table="SwWorkflowTrigger" persist
 	
 	public void function setTriggerEvent(required string triggerEvent){
 		variables.triggerEvent = arguments.triggerEvent;
-		var eventNameOptions = getService('hibachiEventService').getTriggerEventRBKeyHashMapByEntityName(this.getWorkflow().getWorkflowObject());
+		var eventNameOptions = {};
+		if(!isNull(this.getWorkflow()) && !isNull(this.getWorkflow().getWorkflowObject())){
+			eventNameOptions = getService('hibachiEventService').getTriggerEventRBKeyHashMapByEntityName(this.getWorkflow().getWorkflowObject());	
+		}
 		
 		if(structKeyExists(eventNameOptions,arguments.triggerEvent)){
 			variables.triggerEventTitle = eventNameOptions[arguments.triggerEvent];

--- a/org/Hibachi/client/src/core/services/hibachiservicedecorator.ts
+++ b/org/Hibachi/client/src/core/services/hibachiservicedecorator.ts
@@ -820,7 +820,10 @@ class HibachiServiceDecorator{
                         var savePromise = $delegate.saveEntity(entityName,entityID,params,context);
                         savePromise.then(function(response){
                             var returnedIDs = response.data;
-                            if(angular.isDefined(response.SUCCESS) && response.SUCCESS === true){
+                            if(
+                                (angular.isDefined(response.SUCCESS) && response.SUCCESS === true)
+                                || (angular.isDefined(response.success) && response.success === true)
+                            ){
 
                                 if($location.url() == '/entity/'+entityName+'/create' && response.data[modifiedData.objectLevel.$$getIDName()]){
                                     $location.path('/entity/'+entityName+'/'+response.data[modifiedData.objectLevel.$$getIDName()], false);

--- a/org/Hibachi/client/src/form/components/swinput.ts
+++ b/org/Hibachi/client/src/form/components/swinput.ts
@@ -308,11 +308,10 @@ class SWInputController{
 		var eventNameForObjectSuccessID = this.eventNameForObjectSuccess+this.property;
 
 		var eventNameForUpdateBindings = 'updateBindings';
-		var eventNameForUpdateBindingsID = this.object.metaData.className.split('_')[0]+'updateBindings';
+		var eventNameForUpdateBindingsID = this.object.metaData.className.split('_')[0]+this.property+'updateBindings';
         
         var eventNameForPullBindings = 'pullBindings';
-        var eventNameForPullBindingsID = this.object.metaData.className.split('_')[0]+'pullBindings';
-
+        var eventNameForPullBindingsID = this.object.metaData.className.split('_')[0]+this.property+'pullBindings';
 		//attach a successObserver
 		if(this.object){
 			//update bindings on save success

--- a/org/Hibachi/client/src/workflow/components/swworkflowtriggers.ts
+++ b/org/Hibachi/client/src/workflow/components/swworkflowtriggers.ts
@@ -68,6 +68,8 @@ class SWWorkflowTriggers{
                             if(angular.isDefined(newValue.data.scheduleCollection)){
                                 scope.selectedCollection = newValue.data.scheduleCollection.data.collectionName;
                             }
+                        }else{
+                            scope.searchEvent.name = scope.workflowTriggers.selectedTrigger.triggerEventTitle;
                         }
                     }
                 });
@@ -81,6 +83,7 @@ class SWWorkflowTriggers{
                     scope.collectionCollectionConfig.addFilter("collectionObject",item.value);
                     scope.eventOptions = [];
                 },'WorkflowWorkflowObjectOnChange');
+                
 
                 scope.scheduleCollectionConfig = collectionConfigService.newCollectionConfig("Schedule");
                 scope.scheduleCollectionConfig.setDisplayProperties("scheduleID,scheduleName,daysOfMonthToRun,daysOfWeekToRun,recuringType,frequencyStartTime,frequencyEndTime,frequencyInterval");
@@ -202,8 +205,6 @@ class SWWorkflowTriggers{
                     //Needs to clear old and set new.
                     scope.workflowTriggers.selectedTrigger.data.triggerEventTitle = eventOption.name;
                     scope.workflowTriggers.selectedTrigger.data.triggerEvent = eventOption.value;
-                    console.log(scope.workflowTriggers.selectedTrigger.data.triggerEvent);
-                    console.log(scope.workflowTriggers);
                     if(eventOption.entityName == scope.workflow.data.workflowObject){
                         scope.workflowTriggers.selectedTrigger.data.objectPropertyIdentifier = '';
 
@@ -213,7 +214,10 @@ class SWWorkflowTriggers{
                     
                     scope.searchEvent.name = eventOption.name;
                     scope.showEventOptions = false;  
-                    observerService.notify('pullBindings').then(function(){
+                    observerService.notifyById('pullBindings','WorkflowTriggertriggerEventpullBindings').then(function(){
+                          
+                    });
+                    observerService.notifyById('pullBindings','WorkflowTriggertriggerEventTitlepullBindings').then(function(){
                           
                     });
 				};


### PR DESCRIPTION
didn't need data. bug fix when workflow has no object. binding search
name on edit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4897)
<!-- Reviewable:end -->
