### PR TITLE
I'm adding this because the public account controller method

### DIFF
--- a/model/entity/SubscriptionUsage.cfc
+++ b/model/entity/SubscriptionUsage.cfc
@@ -62,7 +62,7 @@ component entityname="SlatwallSubscriptionUsage" table="SwSubsUsage" persistent=
 
 	// Related Object Properties (many-to-one)
 	property name="account" cfc="Account" fieldtype="many-to-one" fkcolumn="accountID";
-	property name="accountPaymentMethod" cfc="AccountPaymentMethod" fieldtype="many-to-one" fkcolumn="accountPaymentMethodID";
+	property name="accountPaymentMethod" hb_populateEnabled="public" cfc="AccountPaymentMethod" fieldtype="many-to-one" fkcolumn="accountPaymentMethodID";
 	property name="gracePeriodTerm" cfc="Term" fieldtype="many-to-one" fkcolumn="gracePeriodTermID";
 	property name="initialTerm" cfc="Term" fieldtype="many-to-one" fkcolumn="initialTermID";
 	property name="initialOrderItem" cfc="OrderItem" fieldtype="many-to-one" fkcolumn="initialOrderItemID";


### PR DESCRIPTION
updateSubscriptionUsage can't work for updating the account payment
method without this set to public. The controller method is already
making sure that the account on the subscription usage matches the
account making the change, so this should be ok. This should fix the
same functionality in the sample app as well. I will need this merged for the latest Inc update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4899)
<!-- Reviewable:end -->
