### PR TITLE
Modified the getEventConflictExistsFlag to only check if the skus is not

### DIFF
--- a/model/entity/Sku.cfc
+++ b/model/entity/Sku.cfc
@@ -415,10 +415,12 @@ component entityname="SlatwallSku" table="SwSku" persistent=true accessors=true 
 	// END: Image Methods
 
 	public boolean function getEventConflictExistsFlag() {
-		var eventConflictsSmartList = getService("skuService").getEventConflictsSmartList(sku=this);
-		
-		if(eventConflictsSmartList.getRecordsCount() GT 0) {
-			return true;
+		if( ! this.getBundleFlag()){
+			var eventConflictsSmartList = getService("skuService").getEventConflictsSmartList(sku=this);
+			
+			if(eventConflictsSmartList.getRecordsCount() GT 0) {
+				return true;
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
a sku bundle. We're already ignoring sku bundles from the conflict
search but just needed to make sure we weren't running that check from
the sku bundle side

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4960)
<!-- Reviewable:end -->
