### PR TITLE
updates to fix issue deleting orderitems.

### DIFF
--- a/model/dao/OrderDAO.cfc
+++ b/model/dao/OrderDAO.cfc
@@ -315,6 +315,19 @@ Notes:
 			return true;
 		}
 	</cfscript>
+	<cffunction name="removeSelectedShippingMethodOptionFromOrderFulfillments">
+		<cfargument name="orderFulfillmentID" type="string" required="true" >
 
+		<cfset var rs = "" />
+
+		<cfquery name="rs">
+			UPDATE
+				SwOrderFulfillment
+			SET
+				selectedShippingMethodOptionID = null
+			WHERE
+				orderFulfillmentID = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.orderFulfillmentID#" />
+		</cfquery>
+	</cffunction>
 </cfcomponent>
 

--- a/model/entity/Order.cfc
+++ b/model/entity/Order.cfc
@@ -1116,6 +1116,11 @@ component displayname="Order" entityname="SlatwallOrder" table="SwOrder" persist
 		arguments.orderFulfillment.setOrder( this );
 	}
 	public void function removeOrderFulfillment(required any orderFulfillment) {
+		//must do this to handle the related calculated property on orderFulfillment.
+		if (!isNull(arguments.orderFulfillment.getSelectedShippingMethodOption())){
+			var dao = getDao("OrderDAO");
+			dao.removeSelectedShippingMethodOptionFromOrderFulfillments(arguments.orderFulfillment);
+		}
 		arguments.orderFulfillment.removeOrder( this );
 	}
 

--- a/org/Hibachi/HibachiDAO.cfc
+++ b/org/Hibachi/HibachiDAO.cfc
@@ -100,7 +100,8 @@
 
 	    	// Loop over the modifiedEntities to call updateCalculatedProperties
 	    	for(var entity in getHibachiScope().getModifiedEntities()){
-	    		entity.updateCalculatedProperties();
+	    		var mergedEntity = entityMerge(entity);
+	    		mergedEntity.updateCalculatedProperties();
 	    	}
 
 	    	// flush again to persist any changes done during ORM Event handler


### PR DESCRIPTION
Because orderfulfillment has a calculated property that is a relationship rather than a simple property (to selectedShippingMethodOption), entitymerge needed to be added to flushORMSession to get the entity back onto the session after the initial flush.

Once that was fixed, a constraint was being thrown from orderFulfillment to shippingMethodOptionID. I fixed that by (after trying javacast null on orderFulfillment side and the other way around) adding a DAO method to remove the id from orderFulfillment. With that working, removing orderItems works again.

Thanks for the help Sumit.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4964)

<!-- Reviewable:end -->
