### PR TITLE
Incorrectly removed 'return this;'

### DIFF
--- a/model/transient/ResponseBean.cfc
+++ b/model/transient/ResponseBean.cfc
@@ -63,5 +63,7 @@ component accessors="true" displayname="ResponseBean" hint="bean to encapsulate 
 				setterMethod(arguments[key]);	
 			}
 		}
+		
+		return this;
 	} 
 } 


### PR DESCRIPTION
Response bean init method's weren't returning the object.  This was incorrectly removed in the following commit: https://github.com/ten24/slatwall/commit/b64e23404d654fdb03fe3060d42b4db25afeefa5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4985)
<!-- Reviewable:end -->
