### PR TITLE
Update Hibachi.cfc

### DIFF
--- a/org/Hibachi/Hibachi.cfc
+++ b/org/Hibachi/Hibachi.cfc
@@ -247,12 +247,6 @@ component extends="FW1.framework" {
 						getHibachiScope().getSession().setAccount( account );
 					}
 				}
-			// If there is no account on the session, then we can look for an authToken to setup that account for this one request
-			}else if(!getHibachiScope().getLoggedInFlag() && structKeyExists(request, "context") && structKeyExists(request.context, "authToken") && len(request.context.authToken)) {
-				var authTokenAccount = getHibachiScope().getDAO('hibachiDAO').getAccountByAuthToken(authToken=request.context.authToken);
-				if(!isNull(authTokenAccount)) {
-					getHibachiScope().getSession().setAccount( authTokenAccount );
-				}
 			}
 			
 			// Call the onEveryRequest() Method for the parent Application.cfc


### PR DESCRIPTION
Removes the auth token check in Hibachi because it has been replaced. This check in conjunction with another change that was made to core in HibachiDAO are causing api lookup failures on custom projects.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/4988)
<!-- Reviewable:end -->
