### PR TITLE
Update main.less

### DIFF
--- a/admin/client/css/main.less
+++ b/admin/client/css/main.less
@@ -2186,7 +2186,7 @@ a.disabled > i.hibachi-ui-radio-checked {background-position:-16px -64px !import
 .s-upload-image .thumbnail .s-image-info .s-name {font-weight: 600;font-style: italic;}
 .thumbnail .s-title {position: absolute;left: 0px;right: 0px;bottom: 0px;padding: 4px 10px 50px 10px;background-color: @background;pointer-events: none;border-top: 1px solid #eee;color: #666;font-size: 11px;text-align: center;}
 .thumbnail .s-title.s-top {bottom: 29px;border-bottom: 1px solid #fff;}
-.s-upload-image .thumbnail .s-image > a {height: 189px;width: 100%;text-align:center;display: block;}
+.s-upload-image .thumbnail .s-image > a {width: 100%;text-align:center;display: block;}
 .s-upload-image .thumbnail .s-image > a i {font-size: 50px;top: 30%;}
 .s-upload-image.s-new-image .thumbnail .s-controlls {border-top: 1px solid #DDD;} 
 .s-upload-image a {text-decoration: none;}


### PR DESCRIPTION
Minor fix to stop the images overflowing past the edit/delete buttons (at least in chrome):

![image](https://cloud.githubusercontent.com/assets/474990/20119327/19b8aea2-a5d6-11e6-9249-fef0a5187aaf.png)
