### PR TITLE
Fixing an issue where multiple associations were being created on swcontentcategory

### DIFF
--- a/integrationServices/mura/model/handler/MuraEventHandler.cfc
+++ b/integrationServices/mura/model/handler/MuraEventHandler.cfc
@@ -1271,6 +1271,8 @@
 					count(SwContent.contentID) as missingCount
 				FROM
 					tcontentcategoryassign
+				  INNER JOIN 
+				  	tcontent on tcontentcategoryassign.contentID=tcontent.contentID and tcontentcategoryassign.contentHistID=tcontent.contentHistID and tcontent.active=1
 				  INNER JOIN
 				  	SwContent on tcontentcategoryassign.contentID = SwContent.cmsContentID
 				  INNER JOIN
@@ -1293,6 +1295,8 @@
 						SwCategory.categoryID
 					FROM
 						tcontentcategoryassign
+					  INNER JOIN 
+				  	    tcontent on tcontentcategoryassign.contentID=tcontent.contentID and tcontentcategoryassign.contentHistID=tcontent.contentHistID and tcontent.active=1
 					  INNER JOIN
 					  	SwContent on tcontentcategoryassign.contentID = SwContent.cmsContentID
 					  INNER JOIN


### PR DESCRIPTION
Won't clean up any existing repeated rows in the DB though.. I imagine you'll want to do a quick update script for that: Truncate swcontentcategory and let it rebuild.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5005)
<!-- Reviewable:end -->
