### PR TITLE
Develop shipping cost estimator directive

### DIFF
--- a/org/Hibachi/client/src/frontend/components/shippingcostestimator.html
+++ b/org/Hibachi/client/src/frontend/components/shippingcostestimator.html
@@ -1,0 +1,3 @@
+<!--- This partial is left intentionally blank --->
+
+

--- a/org/Hibachi/client/src/frontend/components/swshippingcostestimator.ts
+++ b/org/Hibachi/client/src/frontend/components/swshippingcostestimator.ts
@@ -1,0 +1,74 @@
+/// <reference path='../../../typings/hibachiTypescript.d.ts' />
+/// <reference path='../../../typings/tsd.d.ts' />
+declare var hibachiConfig:any;
+
+class SWShippingCostEstimatorController {
+    private hibachiScope;
+    private address;
+    private skuCode
+    //@ngInject
+    constructor(private $log, public $rootScope) {
+        this.$rootScope = $rootScope;
+        this.hibachiScope = this.$rootScope.hibachiScope;
+
+        if (this.address != undefined){
+
+        }
+        if (this.skuCode != undefined){
+
+        }
+    }
+}
+
+class SWShippingCostEstimator implements ng.IDirective {
+    
+    public restrict: string = 'E';
+    public scope: any;
+    public bindToController = {
+        address: "=",
+        skucode: "=",
+        templateUrl: "@"
+    };
+    public controller = SWShippingCostEstimatorController
+    public controllerAs = "SwShippingCostEstimatorController";
+    public templatePath: string = "";
+    public url: string = "";
+    public $compile;
+    public path: string;
+    
+    // @ngInject
+    constructor(hibachiPathBuilder, $compile) {
+        if(!hibachiConfig){
+            hibachiConfig = {};    
+        }
+        
+        if (!hibachiConfig.customPartialsPath) {
+            hibachiConfig.customPartialsPath = 'custom/client/src/frontend/';
+        }
+
+        this.templatePath = hibachiConfig.customPartialsPath;
+        this.url = hibachiConfig.customPartialsPath + 'shippingcostestimator.html';
+        this.$compile = $compile;
+    }
+    
+    
+
+
+    public static Factory(): ng.IDirectiveFactory {
+        var directive: ng.IDirectiveFactory = (
+            hibachiPathBuilder,
+            $compile
+        ) => new SWShippingCostEstimator(
+            hibachiPathBuilder,
+            $compile
+        );
+        directive.$inject = [
+            'hibachiPathBuilder',
+            '$compile'
+        ];
+        return directive;
+    }
+}
+export {SWShippingCostEstimatorController, SWShippingCostEstimator};
+    
+    

--- a/org/Hibachi/client/src/frontend/components/swshippingcostestimator.ts
+++ b/org/Hibachi/client/src/frontend/components/swshippingcostestimator.ts
@@ -5,19 +5,35 @@ declare var hibachiConfig:any;
 class SWShippingCostEstimatorController {
     private hibachiScope;
     private address;
-    private skuCode
+    private skuCode;
+    public estimatedShippingRates:any;
+
     //@ngInject
     constructor(private $log, public $rootScope) {
         this.$rootScope = $rootScope;
         this.hibachiScope = this.$rootScope.hibachiScope;
 
-        if (this.address != undefined){
-
+        if ( this.skuCode && this.address ){
+            this.getEstimatedShippingCosts(this.skuCode, this.address);
         }
-        if (this.skuCode != undefined){
-
+        if ( this.skuCode && this.address ){
+            this.getEstimatedShippingCosts(this.skuCode);
         }
     }
+
+    /** Get the estimated shipping rates. */
+    public getEstimatedShippingCosts = ( skuCode?:any, address?:any ) => {
+        this.$rootScope.slatwall.doAction("getEstimatedShippingRates", {skuCode: skuCode, address: address||{}}).then((result)=>{
+            if (result.estimatedShippingRates != undefined){
+                this.estimatedShippingRates = result;
+            }    
+            else {
+                this.estimatedShippingRates = [];
+            }
+        
+        });
+    }
+
 }
 
 class SWShippingCostEstimator implements ng.IDirective {

--- a/org/Hibachi/client/src/frontend/frontend.module.ts
+++ b/org/Hibachi/client/src/frontend/frontend.module.ts
@@ -6,6 +6,7 @@ import {hibachimodule} 	from "../hibachi/hibachi.module";
 import {FrontendController} from './controllers/frontend';
 //directives
 import {SWFDirective} 		from "./components/swfdirective";
+import {SWShippingCostEstimator} from "./components/swshippingcostestimator";
 
 declare var hibachiConfig:any;
 //need to inject the public service into the rootscope for use in the directives.


### PR DESCRIPTION
This is a simple directive that lets frontend user pass in a skucode and or address and get back data for shipping costs. The template is blank as we will define it on a site by site basis. Usage is:

<sw-estimated-shipping-costs skuCode="someSku">
   <!--- You can access the data using --->
   <span ng-bind="SwEstimatedShippingCostsController.estimatedShippingCosts">
</sw...>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5080)
<!-- Reviewable:end -->
