### PR TITLE
Fixing Product Create With Options Selected 

### DIFF
--- a/admin/client/src/product/controllers/preprocessproduct_create.ts
+++ b/admin/client/src/product/controllers/preprocessproduct_create.ts
@@ -106,7 +106,8 @@ class ProductCreateController{
             } else {
                 this.$scope.preprocessproduct_createCtrl.selectedOption.value = "";
             }
-          
+
+            this.$scope.preprocessproduct_createCtrl.getCollection();
         }
 
 }

--- a/org/Hibachi/client/src/core/components/listingdisplay.html
+++ b/org/Hibachi/client/src/core/components/listingdisplay.html
@@ -149,7 +149,7 @@
                                 		ng-if="swListingDisplay.multiselectable"
                                         data-id="pageRecord[swListingDisplay.exampleEntity.$$getIDName()]"
                                         data-is-radio="swListingDisplay.isRadio"
-                                        data-selectionid="{{swListingDisplay.name || 'ListingDisplay'}}"
+                                        data-selectionid="{{swListingDisplay.tableID}}"
                                         data-selection="pageRecord[swListingDisplay.exampleEntity.$$getIDName()]"
                                         data-name="{{swListingDisplay.multiselectFieldName+'selection'}}"
                                         data-disabled="swListingDisplay.edit === false">

--- a/org/Hibachi/client/src/core/components/swlistingdisplay.ts
+++ b/org/Hibachi/client/src/core/components/swlistingdisplay.ts
@@ -154,10 +154,11 @@ class SWListingDisplayController{
                 if(angular.isUndefined(this.getCollection)){
                     this.getCollection = this.listingService.setupDefaultGetCollection(this.tableID);
                 }
+                
                 this.paginator.getCollection = this.getCollection;
-        		var getCollectioneventID= (this.name || 'ListingDisplay');
-        		this.observerService.attach(this.getCollectionObserver,'getCollection',getCollectioneventID);
-        
+        		
+                var getCollectionEventID = this.tableId;
+        		this.observerService.attach(this.getCollectionObserver,'getCollection',getCollectionEventID);
             }
         );
         
@@ -175,7 +176,11 @@ class SWListingDisplayController{
     };
 
     private initializeState = () =>{
-        this.tableID = 'LD'+this.utilityService.createID();
+        if(angular.isDefined(this.name)){
+            this.tableID = this.name; 
+        } else {
+            this.tableID = 'LD'+this.utilityService.createID();
+        }
         if (angular.isUndefined(this.collectionConfig)){
             //make it available to swCollectionConfig
             this.collectionConfig = null; 
@@ -235,9 +240,6 @@ class SWListingDisplayController{
         }
         if(angular.isUndefined(this.showOrderBy)){
             this.showOrderBy = true; 
-        }
-        if(angular.isUndefined(this.name)){
-            this.name = 'ListingDisplay';
         }
         if(angular.isUndefined(this.expandable)){
             this.expandable = false; 
@@ -333,11 +335,11 @@ class SWListingDisplayController{
     };
 
     public updateMultiselectValues = (res)=>{
-        this.multiselectValues = this.selectionService.getSelections(this.name);
-        if(this.selectionService.isAllSelected(this.name)){
-            this.multiselectCount = this.collectionData.recordsCount - this.selectionService.getSelectionCount(this.name);
+        this.multiselectValues = this.selectionService.getSelections(this.tableId);
+        if(this.selectionService.isAllSelected(this.tableId)){
+            this.multiselectCount = this.collectionData.recordsCount - this.selectionService.getSelectionCount(this.tableId);
         }else{
-            this.multiselectCount = this.selectionService.getSelectionCount(this.name);
+            this.multiselectCount = this.selectionService.getSelectionCount(this.tableId);
         }
         switch (res.action){
             case 'uncheck':
@@ -379,15 +381,15 @@ class SWListingDisplayController{
     public exportCurrentList =(selection:boolean=false)=>{
         if(this.collectionConfigs.length == 0){
             var exportCollectionConfig = angular.copy(this.collectionConfig.getCollectionConfig());
-            if (selection && !angular.isUndefined(this.selectionService.getSelections(this.name))
-                && (this.selectionService.getSelections(this.name).length > 0)) {
+            if (selection && !angular.isUndefined(this.selectionService.getSelections(this.tableID))
+                && (this.selectionService.getSelections(this.tableID).length > 0)) {
                 exportCollectionConfig.filterGroups[0].filterGroup = [
                     {
                         "displayPropertyIdentifier": this.rbkeyService.getRBKey("entity."+exportCollectionConfig.baseEntityName.toLowerCase()+"."+this.exampleEntity.$$getIDName().toLowerCase()),
                         "propertyIdentifier": exportCollectionConfig.baseEntityAlias + "."+this.exampleEntity.$$getIDName(),
                         "comparisonOperator": (this.allSelected) ? "not in":"in",
-                        "value": this.selectionService.getSelections(this.name).join(),
-                        "displayValue": this.selectionService.getSelections(this.name).join(),
+                        "value": this.selectionService.getSelections(this.tableID).join(),
+                        "displayValue": this.selectionService.getSelections(this.tableID).join(),
                         "ormtype": "string",
                         "fieldtype": "id",
                         "conditionDisplay": "In List"
@@ -414,11 +416,11 @@ class SWListingDisplayController{
 
     //these are no longer going to work
     public clearSelection=()=>{
-        this.selectionService.clearSelection(this.name);
+        this.selectionService.clearSelection(this.tableID);
     };
 
     public selectAll=()=>{
-        this.selectionService.selectAll(this.name);
+        this.selectionService.selectAll(this.tableID);
     };
 }
 

--- a/org/Hibachi/client/src/core/components/swlistingdisplay.ts
+++ b/org/Hibachi/client/src/core/components/swlistingdisplay.ts
@@ -151,12 +151,10 @@ class SWListingDisplayController{
             }
         ).finally(
             ()=>{
-                //if getCollection doesn't exist then create it
                 if(angular.isUndefined(this.getCollection)){
                     this.getCollection = this.listingService.setupDefaultGetCollection(this.tableID);
                 }
                 this.paginator.getCollection = this.getCollection;
-                //this.getCollection();
         		var getCollectioneventID= (this.name || 'ListingDisplay');
         		this.observerService.attach(this.getCollectionObserver,'getCollection',getCollectioneventID);
         

--- a/org/Hibachi/client/src/core/components/swlistingdisplay.ts
+++ b/org/Hibachi/client/src/core/components/swlistingdisplay.ts
@@ -335,11 +335,12 @@ class SWListingDisplayController{
     };
 
     public updateMultiselectValues = (res)=>{
-        this.multiselectValues = this.selectionService.getSelections(this.tableId);
-        if(this.selectionService.isAllSelected(this.tableId)){
-            this.multiselectCount = this.collectionData.recordsCount - this.selectionService.getSelectionCount(this.tableId);
+        this.multiselectValues = this.selectionService.getSelections(this.tableID);
+        console.log("updateMultiselectValues", this.multiselectValues);
+        if(this.selectionService.isAllSelected(this.tableID)){
+            this.multiselectCount = this.collectionData.recordsCount - this.selectionService.getSelectionCount(this.tableID);
         }else{
-            this.multiselectCount = this.selectionService.getSelectionCount(this.tableId);
+            this.multiselectCount = this.selectionService.getSelectionCount(this.tableID);
         }
         switch (res.action){
             case 'uncheck':

--- a/org/Hibachi/client/src/core/services/listingservice.ts
+++ b/org/Hibachi/client/src/core/services/listingservice.ts
@@ -232,10 +232,10 @@ class ListingService{
 
         for(var i = 0; i < this.getListing(listingID).collectionData.pageRecords.length; i++){
             if( this.getListing(listingID).isCurrentPageRecordsSelected == true ){
-                this.getListing(listingID).selectionService.addSelection(this.getListing(listingID).name, 
+                this.getListing(listingID).selectionService.addSelection(this.getListing(listingID).tableID, 
                                                                          this.getListingPageRecords(listingID)[i][this.getListingBaseEntityPrimaryIDPropertyName(listingID)]);
             } else {
-                this.selectionService.removeSelection(this.getListing(listingID).name,  this.getListingPageRecords(listingID)[i][this.getListingBaseEntityPrimaryIDPropertyName(listingID)]);
+                this.selectionService.removeSelection(this.getListing(listingID).tableID,  this.getListingPageRecords(listingID)[i][this.getListingBaseEntityPrimaryIDPropertyName(listingID)]);
             }
         }
     };
@@ -594,14 +594,14 @@ class ListingService{
         if(this.getListing(listingID).multiselectValues && this.getListing(listingID).multiselectValues.length){
             //select all owned ids
             angular.forEach(this.getListing(listingID).multiselectValues,(value)=>{
-                this.getListing(listingID).selectionService.addSelection(this.getListing(listingID).name,value);
+                this.getListing(listingID).selectionService.addSelection(this.getListing(listingID).tableID,value);
             });
         }
 
         if(this.getListing(listingID).multiselectIdPaths && this.getListing(listingID).multiselectIdPaths.length){
             angular.forEach(this.getListing(listingID).multiselectIdPaths.split(','),(value)=>{
                 var id = this.getListing(listingID).utilityService.listLast(value,'/');
-                this.getListing(listingID).selectionService.addSelection(this.getListing(listingID).name,id);
+                this.getListing(listingID).selectionService.addSelection(this.getListing(listingID).tableID,id);
             });
         }
     };


### PR DESCRIPTION
This also includes a refactor to the way that Listing Display / Service work with the selection service. It previously keyed off of the listing display's name, but that was before tableID was created. Now it will use tableID, and for older listing displays it will copy name and use it as tableID

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5096)
<!-- Reviewable:end -->
