### PR TITLE
fix casing issue and remove function call thats not needed.

### DIFF
--- a/model/entity/Collection.cfc
+++ b/model/entity/Collection.cfc
@@ -639,7 +639,7 @@ component displayname="Collection" entityname="SlatwallCollection" table="SwColl
 			}
 			
 			//Handle pagination.
-			if(key.contains('p:current')){
+			if(findNoCase('p:current', key)){
 				var currentPage = data[key];
 			}
 			if (!isNull(currentPage)){
@@ -647,12 +647,14 @@ component displayname="Collection" entityname="SlatwallCollection" table="SwColl
 				this.setPageRecordsStart(currentPage);
 			}
 			
-			if(key.contains('p:show')){
+			if(findNoCase('p:show', key)){
 				var pageShow = data[key];
-			} 
+			}
+			
 			if (!isNull(pageShow)){
 				this.setPageRecordsShow(pageShow);	
 			}
+			
 			
 		}
 	}

--- a/org/Hibachi/HibachiCollectionService.cfc
+++ b/org/Hibachi/HibachiCollectionService.cfc
@@ -524,7 +524,7 @@ component output="false" accessors="true" extends="HibachiService" {
 			}
 		}
 		
-		if(!structKeyExists(newQueryKeys, "P#variables.dataKeyDelimiter#Show") || newQueryKeys["P#variables.dataKeyDelimiter#Show"] == getPageRecordsShow()) {
+		if(!structKeyExists(newQueryKeys, "P#variables.dataKeyDelimiter#Show")) {
 			// Add the correct page start
 			if( structKeyExists(newQueryKeys, "P#variables.dataKeyDelimiter#Start") ) {
 				modifiedURL &= "P#variables.dataKeyDelimiter#Start=#newQueryKeys[ 'P#variables.dataKeyDelimiter#Start' ]#&";


### PR DESCRIPTION
This makes it so the case in the url for these pagination filters doesn't matter and so it doesn't throw an error on using p:current.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5114)
<!-- Reviewable:end -->
