### PR TITLE
removes 'product' from the post data to fix issue with the renewalPrice

### DIFF
--- a/admin/views/entity/preprocessproduct_addsubscriptionsku.cfm
+++ b/admin/views/entity/preprocessproduct_addsubscriptionsku.cfm
@@ -83,7 +83,7 @@ Notes:
 			<hb:HibachiPropertyList divClass="col-md-12">
 
 				<hb:HibachiDisplayToggle selector="select[name='renewalMethod']" showvalues="custom" loadVisable="true">
-						<hb:HibachiPropertyDisplay object="#rc.processObject#" property="renewalPrice" fieldName="product.renewalPrice" edit="#rc.edit#" />
+						<hb:HibachiPropertyDisplay object="#rc.processObject#" property="renewalPrice" fieldName="renewalPrice" edit="#rc.edit#" />
 						<swa:SlatwallErrorDisplay object="#rc.processObject#" errorName="renewalsubscriptionBenefits" />
 						<hb:HibachiListingDisplay smartList="SubscriptionBenefit" multiselectFieldName="renewalSubscriptionBenefits" title="#$.slatwall.rbKey('admin.entity.createProduct.selectRenewalSubscriptionBenefits')#" edit="true">
 							<hb:HibachiListingColumn propertyIdentifier="subscriptionBenefitName" tdclass="primary" />


### PR DESCRIPTION
not being set when creating a subscription sku.

Issue: When creating a new sku under a subscription product, the modal allows the user to set a term, benefit, price, and renewalPrice. The renewalPrice was never being set if you enter it in the field because the field was posting using product.renewalPrice instead of renewalPrice.

Solution: I updated the name of the field. I tested that the value now gets set when creating the sku.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5209)
<!-- Reviewable:end -->
