### PR TITLE
moves the auto update fulfillment items location on save to outside the

### DIFF
--- a/admin/views/entity/preprocessorderfulfillment_fulfillitems.cfm
+++ b/admin/views/entity/preprocessorderfulfillment_fulfillitems.cfm
@@ -72,7 +72,9 @@ Notes:
 				</cfif>
 
 				<!--- Location --->
-				<hb:HibachiPropertyDisplay object="#rc.orderFulfillment#" property="pickupLocation" edit="#rc.edit#">
+				<cfif rc.orderFulfillment.getFulfillmentMethod().getFulfillmentMethodType() eq "pickup">
+ 					<hb:HibachiPropertyDisplay object="#rc.orderFulfillment#" property="pickupLocation" fieldName="location.locationID" edit="#rc.edit#">
+ 				</cfif>
 				<hr />
 
 				<!--- Items Selector --->

--- a/admin/views/entity/preprocessorderfulfillment_fulfillitems.cfm
+++ b/admin/views/entity/preprocessorderfulfillment_fulfillitems.cfm
@@ -73,8 +73,10 @@ Notes:
 
 				<!--- Location --->
 				<cfif rc.orderFulfillment.getFulfillmentMethod().getFulfillmentMethodType() eq "pickup">
- 					<hb:HibachiPropertyDisplay object="#rc.orderFulfillment#" property="pickupLocation" fieldName="location.locationID" edit="#rc.edit#">
- 				</cfif>
+					<hb:HibachiPropertyDisplay object="#rc.orderFulfillment#" property="pickupLocation" fieldName="location.locationID" edit="#rc.edit#">
+				<cfelse>
+					<hb:HibachiFieldDisplay title="#$.slatwall.rbKey('entity.location')#" fieldName="location.locationID" valueOptions="#$.slatwall.getService('locationService').getLocationOptions()#" fieldType="select" edit="true" />
+				</cfif>
 				<hr />
 
 				<!--- Items Selector --->


### PR DESCRIPTION
condition. Updates the view to show the default and fix hard error by
the name being wrong.

Problem:
1. This fixes a hard error in the view on fulfilling the items on a pickup order. This fixes that by updating the name of the property to be location.locationID. I also added a condition to check if it a pickup type before displaying the select.
2. This fixes a problem in saveOrderFulfillment that updates the fulfillment items to use the new fulfillment location if one exists and the stock can be found by sku and location. Because that logic was inside a condition that only runs when the order is not placed, the logic was not being called on placed order. I moved the logic outside that condition to fix the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5214)
<!-- Reviewable:end -->
