### PR TITLE
Fixes spacing issues in swinput.

### DIFF
--- a/org/Hibachi/client/src/form/components/swinput.ts
+++ b/org/Hibachi/client/src/form/components/swinput.ts
@@ -229,15 +229,15 @@ class SWInputController{
                 inputType="text";
             }
 			template = '<input type="'+inputType+'" class="'+this.class+'" '+
-				'ng-model="swInput.value" '+
-				'ng-disabled="swInput.editable === false" '+
-				'ng-show="swInput.editing" '+
-				'name="'+this.property+'" ' +
-				'placeholder="'+placeholder+'" '+
+				' ng-model="swInput.value" '+
+				' ng-disabled="swInput.editable === false" '+
+				' ng-show="swInput.editing" '+
+				' name="'+this.property+'" ' +
+				' placeholder="'+placeholder+'" '+
 				validations + currency +
-				'id="swinput'+this.swForm.name+this.name+'" '+
-				'style="'+style+'"'+
-				this.inputAttributes+
+				' id="swinput'+this.swForm.name+this.name+'" '+
+				' style="' + style + '" ' + " " +
+	            this.inputAttributes + " " +
 				this.eventHandlerTemplate;
 		}
 


### PR DESCRIPTION
This updates the generated template string in swInput to add some space between attributes. There were two issues I was having with this code, this only fixes one of them. The first issue was that the inputAttributes when they get attached touch the previous attributes. The other issue was that because placeholder is already being used with rbKey by default, you can't add you own placeholder to the input.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5235)
<!-- Reviewable:end -->
