### PR TITLE
Fix - percent rewards for currency

### DIFF
--- a/model/entity/PromotionReward.cfc
+++ b/model/entity/PromotionReward.cfc
@@ -153,7 +153,7 @@ component displayname="Promotion Reward" entityname="SlatwallPromotionReward" ta
 
 
 	public numeric function getAmountByCurrencyCode(required string currencyCode){
-		if(arguments.currencyCode neq getCurrencyCode()){
+		if(arguments.currencyCode neq getCurrencyCode() and getAmountType() neq 'percentageOff'){
 			//Check for explicity defined promotion reward currencies
 			for(var i=1;i<=arraylen(variables.promotionRewardCurrencies);i++){
 				if(variables.promotionRewardCurrencies[i].getCurrencyCode() eq arguments.currencyCode){


### PR DESCRIPTION
Percent rewards were being currency converted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5248)
<!-- Reviewable:end -->
