### PR TITLE
Updates Order_AddOrderItem

### DIFF
--- a/meta/tests/unit/process/Order_AddOrderItemTest.cfc
+++ b/meta/tests/unit/process/Order_AddOrderItemTest.cfc
@@ -57,6 +57,7 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 
 		//Testing adding child order items.
 		var psku = getTestSku('TestSku#createUUID()#');
+		psku.setUserDefinedPriceFlag(true);
 		var pstock = getTestStock();
 		var pstock2 = getTestStock();
 		var porderItem = request.slatwallScope.newEntity( 'orderItem' );
@@ -67,6 +68,7 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 		porderItem.setProductBundleGroup("PBG1");
 
 		var sku = getTestSku('TestSku#createUUID()#');
+		sku.setUserDefinedPriceFlag(true);
 		var stock = getTestStock();
 		var stock2 = getTestStock();
 		var orderItem = request.slatwallScope.newEntity( 'orderItem' );
@@ -78,6 +80,7 @@ component extends="Slatwall.meta.tests.unit.SlatwallUnitTestBase" {
 		orderItem.setProductBundleGroup(pOrderItem);
 
 		var sku2 = getTestSku('TestSku#createUUID()#');
+		sku2.setUserDefinedPriceFlag(true);
 		var stock3 = getTestStock();
 		var stock4 = getTestStock();
 		var orderItem2 = request.slatwallScope.newEntity( 'orderItem' );

--- a/model/process/Order_AddOrderItem.cfc
+++ b/model/process/Order_AddOrderItem.cfc
@@ -562,10 +562,11 @@ component output="false" accessors="true" extends="HibachiProcess" {
 		if(arguments.orderItem.getSku().getSkuID() != this.getSku().getSkuID()){
 			return false;
 		}
-		//check if the price is the same
-		if(arguments.orderItem.getPrice() != this.getPrice()){
+		//check if the price is the same if and only if we are using a custom price
+		if(arguments.orderItem.getPrice() != this.getPrice() && (!isNull(arguments.orderItem.getSku().getUserDefinedPriceFlag()) && arguments.orderItem.getSku().getUserDefinedPriceFlag())){
 			return false;
 		}
+		
 		//check if the instock value is the same
 		if(!isNull(arguments.orderItem.getStock()) && !isNull(this.getStock()) && arguments.orderItem.getStock().getStockID() != this.getStock().getStockID()){
 			return false;


### PR DESCRIPTION
There is an issue when adding orderItems in separate requests where the sku is being added as two different items instead of increasing the quantity of the first. This is because of quantity based pricing and this pull request fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5272)
<!-- Reviewable:end -->
