### PR TITLE
Ensure option group sort order is used in skuDefinition

### DIFF
--- a/model/dao/SkuDAO.cfc
+++ b/model/dao/SkuDAO.cfc
@@ -59,6 +59,7 @@ Notes:
 			optionSmartList.addSelect('optionGroup.optionGroupName','optionGroupName');
 			optionSmartList.addSelect('optionName','optionName');
 			optionSmartList.addFilter('skus.skuID',arguments.skuID);
+			optionSmartList.addOrder('optionGroup.sortOrder');
 			optionSmartList.setSelectDistinctFlag(true);
 			
 			for(var item in optionSmartList.getRecords()) {


### PR DESCRIPTION
Ensure that optionGroup sortOrder is used to sequence groups and options for skuDefinition

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5294)
<!-- Reviewable:end -->
