### PR TITLE
Fixes custom assets .gitignore

### DIFF
--- a/custom/assets/.gitignore
+++ b/custom/assets/.gitignore
@@ -1,4 +1,7 @@
 # ignore everything
 *
-# except ckeditor_config.js
+# except .gitignore, ckeditor_config.js, ckeditor_config.js.example, readme.md
+!.gitignore
 !ckeditor_config.js
+!ckeditor_config.js.example
+!readme.md


### PR DESCRIPTION
Under the original way that this worked, the .gitignore itself was ignored from repos if you just did a copy & paste of Slatwall instead of clone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5358)
<!-- Reviewable:end -->
