### PR TITLE
Fixes a type issue that makes it so order audits can not be viewed.

### DIFF
--- a/org/Hibachi/HibachiObject.cfc
+++ b/org/Hibachi/HibachiObject.cfc
@@ -196,7 +196,7 @@ component accessors="true" output="false" persistent="false" {
 		return getHibachiScope().rbKey(arguments.key);
 	}
 	
-	public string function hibachiHTMLEditFormat(required string html=""){
+	public string function hibachiHTMLEditFormat(required any html=""){
 		return getHibachiScope().hibachiHTMLEditFormat(arguments.html);
 	}
 	

--- a/org/Hibachi/HibachiScope.cfc
+++ b/org/Hibachi/HibachiScope.cfc
@@ -265,7 +265,7 @@ component output="false" accessors="true" extends="HibachiTransient" {
 	
 	// ========================== HELPER DELIGATION METHODS ===============================
 	
-	public string function hibachiHTMLEditFormat(required string html){
+	public string function hibachiHTMLEditFormat(required any html){
 		return getService('hibachiUtilityService').hibachiHTMLEditFormat(arguments.html);
 	}
 	

--- a/org/Hibachi/HibachiUtilityService.cfc
+++ b/org/Hibachi/HibachiUtilityService.cfc
@@ -562,7 +562,14 @@
 			}
 		}
 
-		public string function hibachiHTMLEditFormat(required string html){
+		public string function hibachiHTMLEditFormat(required any html=""){
+			//If its something that can be turned into a string, make sure its a string.
+			if (isSimpleValue(arguments.html)){
+				arguments.html = "#arguments.html#";
+			//Otherwise, it can't be passed into htmlEditFormat
+			}else{
+				return "";
+			}
 			var sanitizedString = htmlEditFormat(arguments.html);
 			sanitizedString = sanitizeForAngular(sanitizedString);
 			return sanitizedString;


### PR DESCRIPTION
This fix relates to an issue here: https://ten24.teamwork.com/#/tasks/11757721?c=5875888 and the specific fix was outlines by Ryan in the comments. I tested that this is working in a custom project and that viewing audits no longer throws an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5387)
<!-- Reviewable:end -->
