### PR TITLE
Top nav don't need angular bootstrap to start working

### DIFF
--- a/org/Hibachi/HibachiTags/HibachiActionCallerDropdown.cfm
+++ b/org/Hibachi/HibachiTags/HibachiActionCallerDropdown.cfm
@@ -21,7 +21,7 @@
 		<cfelseif attributes.type eq "nav">
 			<cfoutput>
 				<li class="dropdown">
-					<a href="##" class="dropdown-toggle"><i class="fa fa-#attributes.icon#"></i> #attributes.title# </a>
+					<a href="##" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-#attributes.icon#"></i> #attributes.title# </a>
 					<ul class="dropdown-menu #attributes.dropdownClass#" id="#attributes.dropdownId#">
 						#thisTag.generatedContent#
 						<cfset thisTag.generatedContent = "" />

--- a/org/Hibachi/HibachiTags/HibachiListingDisplay.cfm
+++ b/org/Hibachi/HibachiTags/HibachiListingDisplay.cfm
@@ -426,7 +426,7 @@
 									#column.title#
 								<cfelse>
 									<div class="dropdown">
-										<a href="##" class="dropdown-toggle">#column.title# <i class="fa fa-sort"></i></a>
+										<a href="##" class="dropdown-toggle" data-toggle="dropdown">#column.title# <i class="fa fa-sort"></i></a>
 										<ul class="dropdown-menu nav scrollable">
 											<hb:HibachiDividerHider>
 												<cfif column.sort and not thistag.expandable>


### PR DESCRIPTION
@rmarchandTen24 This will fix the problem with our navbar dropdowns.
We have bootstrap.js and jquery in Slatwall, we don't need to wait for the Angular bootstrap to get it to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5422)
<!-- Reviewable:end -->
