### PR TITLE
Fixes the buttons not working on the listing display.

### DIFF
--- a/org/Hibachi/client/src/listing/components/swlistingdisplay.ts
+++ b/org/Hibachi/client/src/listing/components/swlistingdisplay.ts
@@ -175,6 +175,10 @@ class SWListingDisplayController{
         	this.setupCollectionPromise();
         }
 
+        if (this.collectionObject){
+             this.exampleEntity = this.$hibachi.getEntityExample(this.collectionObject);
+        }
+
     }
     
     private setupCollectionPromise=()=>{


### PR DESCRIPTION
It was noted in this task: https://ten24.teamwork.com/#tasks/12254664 that the listing display icon buttons on workflow were not functioning. I found it was because the exampleEntity was never being defined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5423)
<!-- Reviewable:end -->
