### PR TITLE
Move some logic further into a method.

### DIFF
--- a/model/service/ShippingService.cfc
+++ b/model/service/ShippingService.cfc
@@ -577,10 +577,6 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		// Make sure that the rate is active
 		if(!isNull(shippingMethodRate.getActiveFlag()) && isBoolean(shippingMethodRate.getActiveFlag()) && !shippingMethodRate.getActiveFlag()) {
 			return false;
-		}
-
-		if(!isNull(shippingMethodRate.getSplitShipmentWeight())){
-			return true; 
 		} 
 
 		// Make sure that the orderFulfillment Item Price is within the min and max of rate
@@ -650,6 +646,12 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		if(!isNull(arguments.shippingMethodRate.getAddressZone()) && !getAddressService().isAddressInZone(arguments.shipToAddress, arguments.shippingMethodRate.getAddressZone())) {
 			return false;
 		}
+		
+		//This check must happen after the address check.
+ 		if(!isNull(shippingMethodRate.getSplitShipmentWeight())){
+ 			return true; 
+ 		} 
+ 		
 		
 		// If we have not returned false by now, then return true
 		return true;

--- a/model/service/ShippingService.cfc
+++ b/model/service/ShippingService.cfc
@@ -595,14 +595,16 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		// Make sure that the orderFulfillment Total Weight is within the min and max of rate
 		var lowerWeight = 0;
 		var higherWeight = 100000000;
-		if(!isNull(arguments.shippingMethodRate.getMinimumShipmentWeight())) {
-			lowerWeight = arguments.shippingMethodRate.getMinimumShipmentWeight();
-		}
-		if(!isNull(arguments.shippingMethodRate.getMaximumShipmentWeight())) {
-			higherWeight = arguments.shippingMethodRate.getMaximumShipmentWeight();
-		}
-		if(shipmentWeight lt lowerWeight || shipmentWeight gt higherWeight) {
-			return false;
+		if(isNull(shippingMethodRate.getSplitShipmentWeight())){
+			if(!isNull(arguments.shippingMethodRate.getMinimumShipmentWeight())) {
+				lowerWeight = arguments.shippingMethodRate.getMinimumShipmentWeight();
+			}
+			if(!isNull(arguments.shippingMethodRate.getMaximumShipmentWeight())) {
+				higherWeight = arguments.shippingMethodRate.getMaximumShipmentWeight();
+			}
+			if(shipmentWeight lt lowerWeight || shipmentWeight gt higherWeight) {
+				return false;
+			}
 		}
 
         // Make sure that the orderFulfillment Total Quantity is within the min and max of rate
@@ -646,12 +648,6 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		if(!isNull(arguments.shippingMethodRate.getAddressZone()) && !getAddressService().isAddressInZone(arguments.shipToAddress, arguments.shippingMethodRate.getAddressZone())) {
 			return false;
 		}
-		
-		//This check must happen after the address check.
- 		if(!isNull(shippingMethodRate.getSplitShipmentWeight())){
- 			return true; 
- 		} 
- 		
 		
 		// If we have not returned false by now, then return true
 		return true;


### PR DESCRIPTION
An issue was found in a custom project where the shipping from an international rate was returning a default value before any address was associated with the cart. The issue was the line below, all returned true in the case where the int shipping method was using split shipment. Moving that condition to the end of the function allows the other constrains to work before getting there. In this case, it will fail the address check and not return a value until there is an address.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5434)
<!-- Reviewable:end -->
