### PR TITLE
This is a fix for weight doubling when calculating total weight for

### DIFF
--- a/model/entity/OrderFulfillment.cfc
+++ b/model/entity/OrderFulfillment.cfc
@@ -436,8 +436,11 @@ component displayname="Order Fulfillment" entityname="SlatwallOrderFulfillment" 
     	var totalShippingWeight = 0;
 
     	for( var orderItem in getOrderFulfillmentItems()) {
-    		var convertedWeight = getService("measurementService").convertWeightToGlobalWeightUnit(orderItem.getSku().setting('skuShippingWeight'), orderItem.getSku().setting('skuShippingWeightUnitCode'));
-    		totalShippingWeight = getService('HibachiUtilityService').precisionCalculate(totalShippingWeight + (convertedWeight * orderItem.getQuantity()));
+    		//Only calculate the weight for top level items so that product bundles don't cause weight doubling.
+    		if (isNull(orderItem.getParentOrderItem())){	
+    			var convertedWeight = getService("measurementService").convertWeightToGlobalWeightUnit(orderItem.getSku().setting('skuShippingWeight'), orderItem.getSku().setting('skuShippingWeightUnitCode'));
+    			totalShippingWeight = getService('HibachiUtilityService').precisionCalculate(totalShippingWeight + (convertedWeight * orderItem.getQuantity()));
+    		}
     	}
 
     	return totalShippingWeight;


### PR DESCRIPTION
bundle items. Currently, it is adding the weight of all items in the
bundle individually + the weight of the bundle. So for a ball product
that weight 17 pounds, sold as a bundle, the fulfillment weight is 34.
17 for the bundle, 17 for the sku. This makes sure it only looks at the
top level for the weight (the top level already includes the child
weights).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5495)
<!-- Reviewable:end -->
