### PR TITLE
Removed attribute loop from order item collection on order detail

### DIFF
--- a/admin/client/src/orderitem/components/sworderitems.ts
+++ b/admin/client/src/orderitem/components/sworderitems.ts
@@ -127,17 +127,6 @@ class SWOrderItems{
 					.setCurrentPage(scope.paginator.getCurrentPage())
  					;
 
-					//add attributes to the column config
-					angular.forEach(scope.attributes,function(attribute){
-						var attributeColumn:any = {
-							propertyIdentifier:"_orderitem."+attribute.attributeCode,
-							attributeID:attribute.attributeID,
-					         attributeSetObject:"orderItem"
-						};
-						orderItemCollection.columns.push(attributeColumn);
-					});
-
-
 					var orderItemsPromise = orderItemCollection.getEntity();
 					orderItemsPromise.then(function(value){
 						scope.collection = value;


### PR DESCRIPTION
Apparently attributes aren't supported by collections, so when there were any attributes for order items this would break order item retrieval.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5498)
<!-- Reviewable:end -->
