### PR TITLE
Updates how the generate unique column works.

### DIFF
--- a/org/Hibachi/HibachiUtilityService.cfc
+++ b/org/Hibachi/HibachiUtilityService.cfc
@@ -185,7 +185,17 @@
 
 			while(!unique) {
 				addon++;
-				returnTitle = "#urlTitle#-#addon#";
+				//check to inc the addon.
+				var idx = len(addon)+1;//+1 for dash
+				if (right(returnTitle, idx) == "-#addon#"){
+					addon++;
+					//increase the addon index and then replace the last two chars instead of appending.
+					var removedLast = Left(returnTitle, len(returnTitle)-idx);
+					returnTitle = "#removedLast#-#addon#";
+				}else{
+					returnTitle = "#urlTitle#-#addon#";	
+				}
+				
 				unique = getHibachiDAO().verifyUniqueTableValue(tableName=arguments.tableName, column=arguments.columnName, value=returnTitle);
 			}
 


### PR DESCRIPTION
There was an issue in a project where the urlTitle was appending a -2 to the end of the property value (name-2, name-2-2, name-2-2-2) instead of just increasing the unique index name-2, name-3, name-4. This update is to resolve that. To fix it, if the value being appended to already has that value at the end, it replaces it instead of just appending.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5501)
<!-- Reviewable:end -->
