### PR TITLE
Adds the call to removeProduct when removing the product listing back

### DIFF
--- a/model/service/ProductService.cfc
+++ b/model/service/ProductService.cfc
@@ -1147,9 +1147,7 @@ component extends="HibachiService" accessors="true" {
 		return delete( arguments.product );
 	}
 
-	public boolean function deleteProductListingPage(required any productListingPage){ 
-		
-		arguments.productListingPage.removeContent(); 
+	public boolean function deleteProductListingPage(required any productListingPage){  
 		arguments.productListingPage.removeProduct(); 
 		return delete( arguments.productListingPage ); 
 	}	


### PR DESCRIPTION
in to fix hard error. When we are trying to delete the productListingPage for a product, the product needs to be removed from the relationship, but the content does not. Removing content throws a hard error. Instead this call needs to remove the product and this fixes the hard error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5519)
<!-- Reviewable:end -->
