### PR TITLE
Removes this SEO friendly addition because the html decorations that

### DIFF
--- a/org/Hibachi/client/src/core/core.module.ts
+++ b/org/Hibachi/client/src/core/core.module.ts
@@ -109,7 +109,6 @@ var coremodule = angular.module('hibachi.core',[
     }
     $logProvider.debugEnabled( appConfig.debugFlag );
     
-    $compileProvider.debugInfoEnabled(appConfig.debugFlag);
      $filterProvider.register('likeFilter',function(){
          return function(text){
              if(angular.isDefined(text) && angular.isString(text)){


### PR DESCRIPTION
this removes, are used by the datetime picker. With this turned on, the
timepicker can not work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5537)
<!-- Reviewable:end -->
