### PR TITLE
Adds a check for the minimum order quantity in the validation.

### DIFF
--- a/model/validation/OrderItem.json
+++ b/model/validation/OrderItem.json
@@ -10,7 +10,7 @@
 		"orderItemStatusType":		[{"contexts":"save","required":true}],
 		"orderStatusCode":			[{"contexts":"edit,delete","inList":"ostNotPlaced,ostNew,ostProcessing,ostOnHold"}],
 		"sku":						[{"contexts":"save","required":true}],
-		"quantity":					[{"conditions":"shouldValidateQuantity","contexts":"save","dataType":"numeric","method":"hasQuantityWithinMaxOrderQuantity"}],
+		"quantity":					[{"conditions":"shouldValidateQuantity","contexts":"save","dataType":"numeric","method":"hasQuantityWithinMaxOrderQuantity"},{"conditions":"shouldValidateQuantity","contexts":"save","dataType":"numeric","method":"hasQuantityWithinMinOrderQuantity"}],
 		"quantityDelivered":		[{"contexts":"delete", "eq":0}]
 	}
 }


### PR DESCRIPTION
A client had a time sensitive issue where they needed to min order quantity to work. Currently, minOrderQuantity is not validated against. If you set the minOrderQuantity to 6 for example, you may still add 1-5 to your cart without any message indicating that you have gone below the minimum. I added the following validation to fix the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5545)
<!-- Reviewable:end -->
