### PR TITLE
Updates SwEditFilterItem

### DIFF
--- a/org/Hibachi/client/src/collection/components/sweditfilteritem.ts
+++ b/org/Hibachi/client/src/collection/components/sweditfilteritem.ts
@@ -298,7 +298,7 @@ class SWEditFilterItem{
                                 filterItem.comparisonOperator = selectedFilterProperty.selectedCriteriaType.comparisonOperator;
 
                                 //retrieving implied value or user input | ex. implied:prop is null, user input:prop = "Name"
-                                if(angular.isDefined(selectedFilterProperty.selectedCriteriaType.value.toString())){
+                                if(angular.isDefined(selectedFilterProperty.selectedCriteriaType.value)){
                                     filterItem.value = selectedFilterProperty.selectedCriteriaType.value.toString();
                                 //if has a pattern then we need to evaluate where to add % for like statement
 							    }else if(angular.isDefined(selectedFilterProperty.selectedCriteriaType.pattern)){


### PR DESCRIPTION
Removes a call to toString that is causing you to not save filters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5549)
<!-- Reviewable:end -->
