### PR TITLE
Added mergeCollectionFilter into develop as its being used already by

### DIFF
--- a/model/entity/Collection.cfc
+++ b/model/entity/Collection.cfc
@@ -1102,8 +1102,21 @@ component displayname="Collection" entityname="SlatwallCollection" table="SwColl
 	public boolean function isAggregateFunction(required string propertyIdentifier){
 		return refindNoCase('^(count|sum|avg|min|max)\(', propertyIdentifier);
 	}
-
-
+	
+	public any function mergeCollectionFilter(required any baseCollection, required any currentCollection) {
+		var totalFilterGroups = arrayLen(currentCollection);
+		for(var i =1; i <= totalFilterGroups; i++){
+			if(!ArrayIsDefined(baseCollection, i)){
+				baseCollection[i] = { "filterGroup" = []};
+			}
+			if(arraylen(baseCollection[i].filterGroup) && arraylen(currentCollection[i].filterGroup)){
+				currentCollection[i].filterGroup[1].logicalOperator = 'AND';
+			}
+			ArrayAppend(baseCollection[i].filterGroup, currentCollection[i].filterGroup, true);
+		}
+		return baseCollection;
+	}
+	
 	public void function mergeJoins(required any baseJoins){
 		var currentCollection = getCollectionConfigStruct();
 		if(isNull(currentCollection.joins) || !arraylen(currentCollection.joins)){


### PR DESCRIPTION
hibachiCollectionService. Either this needs to be in develop, or we need to remove the call to this from hibachiCollectionService (export collection function). I have tested the export is working again for collections that have a baseObject in a custom project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5551)
<!-- Reviewable:end -->
