### PR TITLE
Updates the orderitems listing to only display unique orderitems.

### DIFF
--- a/admin/client/src/orderitem/components/orderitems.html
+++ b/admin/client/src/orderitem/components/orderitems.html
@@ -68,7 +68,7 @@
 						<th></th>
 					</tr>
 				</thead>
-				<tbody ng-repeat="orderItem in orderItems" sw-order-item data-order-item="orderItem" data-attributes="attributes" data-order-id="orderId" ng-show="paginator.getRecordsCount()">
+				<tbody ng-repeat="orderItem in orderItems | unique:'orderItemID'" sw-order-item data-order-item="orderItem" data-attributes="attributes" data-order-id="orderId" ng-show="paginator.getRecordsCount()">
 					<!-- Begin Merchandise Row -->
 				</tbody>
 

--- a/admin/client/src/orderitem/components/sworderitems.ts
+++ b/admin/client/src/orderitem/components/sworderitems.ts
@@ -118,7 +118,9 @@ class SWOrderItems{
                          ,orderReturn.returnLocation.primaryAddress.address.postalCode
 						 ,itemTotal,discountAmount,taxAmount,extendedPrice,productBundlePrice,sku.baseProductType
                          ,sku.subscriptionBenefits
-                         ,sku.product.productType.systemCode,sku.options,sku.locations
+						 ,sku.product.productType.systemCode
+						 ,sku.options
+						 ,sku.locations
  						 ,sku.subscriptionTerm.subscriptionTermName
  						 ,sku.imageFile
                          ,stock.location.locationName`


### PR DESCRIPTION
Duplicates can be caused by adding a one-to-many to the display properties ( in
this case it returns the same order item multiple times - once for each
option). I believe that this is expected as that's what the collection returns. Adding the unique filter, removes the duplicates in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5605)
<!-- Reviewable:end -->
