### PR TITLE
Fixed bug in product dao

### DIFF
--- a/model/dao/ProductDAO.cfc
+++ b/model/dao/ProductDAO.cfc
@@ -63,8 +63,8 @@ Notes:
 
 		public void function updateChildrenProductTypeNamePaths(required array productTypeIDs, required string previousProductTypeNamePath, required string newProductTypeNamePath ){
 			var queryService = new query();
-			arguments.contentIDs = listQualify(arguments.productTypeIDs,"'",",");
-			var sql = "UPDATE SwProductType pt SET productTypeNamePath=REPLACE(pt.productTypeNamePath,'#arguments.previousProductTypeNamePath#','#arguments.newProductTypeNamePath#') Where s.productTypeIDs IN (#arguments.productTypeIDs#) ";
+			arguments.productTypeIDsList = listQualify(arrayToList(arguments.productTypeIDs, ","),"'",",");
+			var sql = "UPDATE SwProductType pt SET productTypeNamePath=REPLACE(pt.productTypeNamePath,'#arguments.previousProductTypeNamePath#','#arguments.newProductTypeNamePath#') Where pt.productTypeID IN (#arguments.productTypeIDsList#) ";
 			queryService.execute(sql=sql);
 		}
 		


### PR DESCRIPTION
There was a mistake in the update query that updates all the productTypeNamePaths when the product type name is updated. Was throwing a hard error because it needed a string (list) but was getting an array and some bad query syntax. I tested this is working in a custom project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5698)
<!-- Reviewable:end -->
