### PR TITLE
Hotfix ih shippingservice fix

### DIFF
--- a/model/service/ShippingService.cfc
+++ b/model/service/ShippingService.cfc
@@ -246,9 +246,9 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		// check to make sure that this rate applies to the current orderFulfillment
 		if(
 			isShippingMethodRateUsable(
-				arguments.shippingMethodRate, 
-				arguments.orderFulfillment.getShippingAddress(), 
-				priceGroups
+				shippingMethodRate=arguments.shippingMethodRate, 
+				shipToAddress=arguments.orderFulfillment.getShippingAddress(), 
+				accountPriceGroups=priceGroups
 			)
 		) {
 			return arguments.shippingMethodRate.getShippingIntegration();
@@ -330,9 +330,9 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 					priceGroups = arguments.orderFulfillment.getOrder().getAccount().getPriceGroups();
 				}
 				if (isShippingMethodRateUsable(
-						shippingMethodRate,
-						arguments.orderFulfillment.getShippingAddress(), 
-						priceGroups)){
+						shippingMethodRate=arguments.shippingMethodRate, 
+						shipToAddress=arguments.orderFulfillment.getShippingAddress(), 
+						accountPriceGroups=priceGroups)){
 							
 							var qualifiedRateOption = newQualifiedRateOption(shippingMethodRate, chargeAmount);
 							arrayAppend(qualifiedRateOptions, qualifiedRateOption);
@@ -375,9 +375,9 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 					}
 					// check to make sure that this rate applies to the current orderFulfillment
 					if (isShippingMethodRateUsable(
-						shippingMethodRate,
-						arguments.orderFulfillment.getShippingAddress(), 
-						priceGroups)){
+						shippingMethodRate=arguments.shippingMethodRate, 
+						shipToAddress=arguments.orderFulfillment.getShippingAddress(), 
+						accountPriceGroups=priceGroups)){
 							
 							var qualifiedRateOption = newQualifiedRateOption(
 							shippingMethodRate,

--- a/model/service/ShippingService.cfc
+++ b/model/service/ShippingService.cfc
@@ -574,7 +574,7 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		return true;
 	}
 
-	public boolean function isShippingMethodRateUsable( any shippingMethodRate,  any shipToAddress,  any shipmentWeight, required any shipmentItemPrice, required any shipmentItemQuantity, any accountPriceGroups) {
+	public boolean function isShippingMethodRateUsable( any shippingMethodRate,  any shipToAddress,  any shipmentWeight, any shipmentItemPrice, any shipmentItemQuantity, any accountPriceGroups) {
 		
         
         // *** Make sure that the shipping method rates price-group is one that the user has access to on account.

--- a/model/service/ShippingService.cfc
+++ b/model/service/ShippingService.cfc
@@ -574,7 +574,7 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		return true;
 	}
 
-	public boolean function isShippingMethodRateUsable(required any shippingMethodRate, required any shipToAddress, required any shipmentWeight, required any shipmentItemPrice, required any shipmentItemQuantity, any accountPriceGroups) {
+	public boolean function isShippingMethodRateUsable( any shippingMethodRate,  any shipToAddress,  any shipmentWeight, required any shipmentItemPrice, required any shipmentItemQuantity, any accountPriceGroups) {
 		
         
         // *** Make sure that the shipping method rates price-group is one that the user has access to on account.

--- a/model/service/ShippingService.cfc
+++ b/model/service/ShippingService.cfc
@@ -246,9 +246,9 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		// check to make sure that this rate applies to the current orderFulfillment
 		if(
 			isShippingMethodRateUsable(
-				shippingMethodRate=arguments.shippingMethodRate, 
-				shipToAddress=arguments.orderFulfillment.getShippingAddress(), 
-				accountPriceGroups=priceGroups
+				arguments.shippingMethodRate, 
+				arguments.orderFulfillment.getShippingAddress(), 
+				priceGroups
 			)
 		) {
 			return arguments.shippingMethodRate.getShippingIntegration();
@@ -330,9 +330,9 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 					priceGroups = arguments.orderFulfillment.getOrder().getAccount().getPriceGroups();
 				}
 				if (isShippingMethodRateUsable(
-						shippingMethodRate=shippingMethodRate, 
-						shipToAddress=arguments.orderFulfillment.getShippingAddress(), 
-						accountPriceGroups=priceGroups)){
+						shippingMethodRate,
+						arguments.orderFulfillment.getShippingAddress(), 
+						priceGroups)){
 							
 							var qualifiedRateOption = newQualifiedRateOption(shippingMethodRate, chargeAmount);
 							arrayAppend(qualifiedRateOptions, qualifiedRateOption);
@@ -375,9 +375,9 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 					}
 					// check to make sure that this rate applies to the current orderFulfillment
 					if (isShippingMethodRateUsable(
-						shippingMethodRate=shippingMethodRate, 
-						shipToAddress=arguments.orderFulfillment.getShippingAddress(), 
-						accountPriceGroups=priceGroups)){
+						shippingMethodRate,
+						arguments.orderFulfillment.getShippingAddress(), 
+						priceGroups)){
 							
 							var qualifiedRateOption = newQualifiedRateOption(
 							shippingMethodRate,
@@ -574,8 +574,8 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		return true;
 	}
 
-	public boolean function isShippingMethodRateUsable( any shippingMethodRate,  any shipToAddress,  any shipmentWeight, any shipmentItemPrice, any shipmentItemQuantity, any accountPriceGroups) {
-		
+	public boolean function isShippingMethodRateUsable(required any shippingMethodRate, required any shipToAddress, any accountPriceGroups) {
+			
         
         // *** Make sure that the shipping method rates price-group is one that the user has access to on account.
         //If this rate has price groups assigned but the user does not, then fail.

--- a/model/service/ShippingService.cfc
+++ b/model/service/ShippingService.cfc
@@ -330,7 +330,7 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 					priceGroups = arguments.orderFulfillment.getOrder().getAccount().getPriceGroups();
 				}
 				if (isShippingMethodRateUsable(
-						shippingMethodRate=arguments.shippingMethodRate, 
+						shippingMethodRate=shippingMethodRate, 
 						shipToAddress=arguments.orderFulfillment.getShippingAddress(), 
 						accountPriceGroups=priceGroups)){
 							
@@ -375,7 +375,7 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 					}
 					// check to make sure that this rate applies to the current orderFulfillment
 					if (isShippingMethodRateUsable(
-						shippingMethodRate=arguments.shippingMethodRate, 
+						shippingMethodRate=shippingMethodRate, 
 						shipToAddress=arguments.orderFulfillment.getShippingAddress(), 
 						accountPriceGroups=priceGroups)){
 							


### PR DESCRIPTION
I tested this as a fix to a custom project.
All of the calls to isShippingMethodRateUsable fail because that method has 5 arguments, but only three are passed in now since this refactor: 

https://github.com/ten24/slatwall/commit/fd9500fe7fbaf43b691a8f2be752fbe23d25bbe6

The only issue this causes is that the methodRate and shipToAddress get passed in correctly, but, the shipment weight will always be either undefined if pricegroups are undefined or will be pricegroups instead of integer which causes its own problems. Also, because args were required, and those are no longer passed in, failed because of that as well.

function isShippingMethodRateUsable(
required any shippingMethodRate, 
required any shipToAddress, 
required any shipmentWeight, 
required any shipmentItemPrice, 
required any shipmentItemQuantity, 
any accountPriceGroups) {

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5717)
<!-- Reviewable:end -->
