### PR TITLE
fixing property identifier getting lost when looking up property display options

### DIFF
--- a/org/Hibachi/client/src/core/services/hibachiservice.ts
+++ b/org/Hibachi/client/src/core/services/hibachiservice.ts
@@ -355,7 +355,7 @@ class HibachiService{
 	getPropertyDisplayOptions = (entityName,options) => {
 		var urlString = this.getUrlWithActionPrefix()+'api:main.getPropertyDisplayOptions&entityName='+entityName;
 		var params:any = {};
-		params.property = options.property || '';
+		params.property = options.property || options.propertyIdentifier || '';
 		if(angular.isDefined(options.argument1))  {
 			params.argument1 = options.argument1;
 		}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/5737)
<!-- Reviewable:end -->
