### PR TITLE
Fixed error in Mura admin due to 

### DIFF
--- a/org/Hibachi/Hibachi.cfc
+++ b/org/Hibachi/Hibachi.cfc
@@ -783,7 +783,7 @@ component extends="FW1.framework" {
 
 					// Announce the applicationSetup event
 					getHibachiScope().getService("hibachiEventService").announceEvent("onApplicationSetup");
-					if(updated){
+					if(updated && structKeyExists(request, "action")){
 						redirect(action=request.action,queryString='updated=true');
 					}
 				}


### PR DESCRIPTION
Fixed issue with slatwall-mura plugin throwing error because no 'action' in request.

Slatwall-mura plugin will throw error from eventHandler.onApplicationLoad when trying to use MuraEventHandler to setup request. 

Occurs during the plugin installation process and also with subsequent calls with `?appreload=true&update=true` will throw same error.