### PR TITLE
Updates the actioncaller button

### DIFF
--- a/org/Hibachi/client/src/core/components/actioncaller.html
+++ b/org/Hibachi/client/src/core/components/actioncaller.html
@@ -47,6 +47,7 @@
 	ng-attr-class="{{swActionCaller.class}}" 
 	ng-attr-title="{{swActionCaller.title}}"
 	ng-click="swActionCaller.submit()"
+	ng-keypress="(keyEvent.which === 13)? swActionCaller.submit() : false"
 	ng-disabled="swActionCaller.disabled"
 	><i ng-show="swActionCaller.icon && swActionCaller.icon.length" class="glyphicon glyphicon-{{swActionCaller.icon}}"></i><span ng-bind="swActionCaller.text"></span>
 </button>


### PR DESCRIPTION
Adding a check on keypress 'Enter' and submits the form on enter press. This should make it so every form that uses the action caller button can be submitted using the enter key.