### PR TITLE
Improvements to vendor order entry process and UI

### DIFF
--- a/admin/views/entity/vendorordertabs/vendororderitems.cfm
+++ b/admin/views/entity/vendorordertabs/vendororderitems.cfm
@@ -136,30 +136,61 @@ Notes:
 		<cfif rc.edit and listFindNoCase("vostNew", rc.vendorOrder.getVendorOrderStatusType().getSystemCode())>
 			<h5>#$.slatwall.rbKey('define.add')#</h5>
 			
-			<hb:HibachiListingDisplay smartList="#rc.vendorOrder.getAddVendorOrderItemSkuOptionsSmartList()#"
-									  recordProcessAction="admin:entity.processVendorOrder"
-									  recordProcessQueryString="vendorOrderItemTypeSystemCode=voitPurchase"
-									  recordProcessContext="addVendorOrderItem"
-									  recordProcessEntity="#rc.vendorOrder#"
-									  recordProcessUpdateTableID="LD#replace(rc.vendorOrder.getVendorOrderItemsSmartList().getSavedStateID(),'-','','all')#">
-									    
-				<hb:HibachiListingColumn propertyIdentifier="skuCode" />
-				<hb:HibachiListingColumn propertyIdentifier="skuName" />
-				<hb:HibachiListingColumn propertyIdentifier="price" />
-				<hb:HibachiListingColumn propertyIdentifier="product.productCode" />
-				<hb:HibachiListingColumn propertyIdentifier="product.brand.brandName" />
-				<hb:HibachiListingColumn tdclass="primary" propertyIdentifier="product.productName" />
-				<hb:HibachiListingColumn propertyIdentifier="calculatedSkuDefinition" />
-				<hb:HibachiListingColumn propertyIdentifier="product.productType.productTypeName" />
-				<hb:HibachiListingColumn propertyIdentifier="calculatedQATS" />
-				
-				<hb:HibachiListingColumn processObjectProperty="deliverToLocationID" title="#$.slatwall.rbKey('process.vendorOrder_AddVendorOrderItem.deliverToLocationID')#" fieldClass="span2" />
-				<hb:HibachiListingColumn processObjectProperty="quantity" title="#$.slatwall.rbKey('define.quantity')#" fieldClass="span1" />
-				<hb:HibachiListingColumn propertyIdentifier="inventoryMeasurementUnit.unitCode" sort="false" search="false" />
-				<hb:HibachiListingColumn processObjectProperty="cost" title="#$.slatwall.rbKey('define.cost')#" fieldClass="span1" />
-				<hb:HibachiListingColumn processObjectProperty="vendorSkuCode" title="#$.slatwall.rbKey('process.vendorOrder_AddVendorOrderItem.vendorSkuCode')#" fieldClass="span1"/>
-				
-			</hb:HibachiListingDisplay>
+			<sw-tab-group id="#request.slatwallScope.createHibachiUUID()#">
+				<sw-tab-content id="#request.slatwallScope.createHibachiUUID()#" name="#$.slatwall.rbKey('admin.vendororder.addItems.assigned')#">
+					<hb:HibachiListingDisplay smartList="#rc.vendorOrder.getAddVendorOrderItemSkuOptionsSmartList()#"
+											recordProcessAction="admin:entity.processVendorOrder"
+											recordProcessQueryString="vendorOrderItemTypeSystemCode=voitPurchase"
+											recordProcessContext="addVendorOrderItem"
+											recordProcessEntity="#rc.vendorOrder#"
+											recordProcessUpdateTableID="LD#replace(rc.vendorOrder.getVendorOrderItemsSmartList().getSavedStateID(),'-','','all')#">
+												
+						<hb:HibachiListingColumn propertyIdentifier="skuCode" />
+						<hb:HibachiListingColumn propertyIdentifier="skuName" />
+						<hb:HibachiListingColumn propertyIdentifier="price" />
+						<hb:HibachiListingColumn propertyIdentifier="product.productCode" />
+						<hb:HibachiListingColumn propertyIdentifier="product.brand.brandName" />
+						<hb:HibachiListingColumn tdclass="primary" propertyIdentifier="product.productName" />
+						<hb:HibachiListingColumn propertyIdentifier="calculatedSkuDefinition" />
+						<hb:HibachiListingColumn propertyIdentifier="product.productType.productTypeName" />
+						<hb:HibachiListingColumn propertyIdentifier="calculatedQATS" />
+						
+						<hb:HibachiListingColumn processObjectProperty="deliverToLocationID" title="#$.slatwall.rbKey('process.vendorOrder_AddVendorOrderItem.deliverToLocationID')#" fieldClass="span2" />
+						<hb:HibachiListingColumn processObjectProperty="quantity" title="#$.slatwall.rbKey('define.quantity')#" fieldClass="span1" />
+						<hb:HibachiListingColumn propertyIdentifier="inventoryMeasurementUnit.unitCode" sort="false" search="false" />
+						<hb:HibachiListingColumn processObjectProperty="cost" title="#$.slatwall.rbKey('define.cost')#" fieldClass="span1" />
+						<hb:HibachiListingColumn processObjectProperty="vendorSkuCode" title="#$.slatwall.rbKey('process.vendorOrder_AddVendorOrderItem.vendorSkuCode')#" fieldClass="span1"/>
+						
+					</hb:HibachiListingDisplay>
+				</sw-tab-content>
+
+				<sw-tab-content id="#request.slatwallScope.createHibachiUUID()#" name="#$.slatwall.rbKey('admin.vendororder.addItems.all')#">
+					<hb:HibachiListingDisplay smartList="#rc.vendorOrder.getAddVendorOrderItemAllSkuOptionsSmartList()#"
+											recordProcessAction="admin:entity.processVendorOrder"
+											recordProcessQueryString="vendorOrderItemTypeSystemCode=voitPurchase"
+											recordProcessContext="addVendorOrderItem"
+											recordProcessEntity="#rc.vendorOrder#"
+											recordProcessUpdateTableID="LD#replace(rc.vendorOrder.getVendorOrderItemsSmartList().getSavedStateID(),'-','','all')#">
+												
+						<hb:HibachiListingColumn propertyIdentifier="skuCode" />
+						<hb:HibachiListingColumn propertyIdentifier="skuName" />
+						<hb:HibachiListingColumn propertyIdentifier="price" />
+						<hb:HibachiListingColumn propertyIdentifier="product.productCode" />
+						<hb:HibachiListingColumn propertyIdentifier="product.brand.brandName" />
+						<hb:HibachiListingColumn tdclass="primary" propertyIdentifier="product.productName" />
+						<hb:HibachiListingColumn propertyIdentifier="calculatedSkuDefinition" />
+						<hb:HibachiListingColumn propertyIdentifier="product.productType.productTypeName" />
+						<hb:HibachiListingColumn propertyIdentifier="calculatedQATS" />
+						
+						<hb:HibachiListingColumn processObjectProperty="deliverToLocationID" title="#$.slatwall.rbKey('process.vendorOrder_AddVendorOrderItem.deliverToLocationID')#" fieldClass="span2" />
+						<hb:HibachiListingColumn processObjectProperty="quantity" title="#$.slatwall.rbKey('define.quantity')#" fieldClass="span1" />
+						<hb:HibachiListingColumn propertyIdentifier="inventoryMeasurementUnit.unitCode" sort="false" search="false" />
+						<hb:HibachiListingColumn processObjectProperty="cost" title="#$.slatwall.rbKey('define.cost')#" fieldClass="span1" />
+						<hb:HibachiListingColumn processObjectProperty="vendorSkuCode" title="#$.slatwall.rbKey('process.vendorOrder_AddVendorOrderItem.vendorSkuCode')#" fieldClass="span1"/>
+						
+					</hb:HibachiListingDisplay>
+				</sw-tab-content>
+		</sw-tab-group>
 		</cfif>
 	</cfif>
 </cfoutput>

--- a/config/resourceBundles/en.properties
+++ b/config/resourceBundles/en.properties
@@ -756,6 +756,8 @@ admin.report.exportcsv                                                          
 admin.report.exportxls                                                                  = Export XLS
 admin.setting.settings_nav                                                              = Settings
 admin.setting_nav                                                                       = View A List of Settings
+admin.vendororder.addItems.all                                                          = All Available Items
+admin.vendororder.addItems.assigned                                                     = Assigned Items
 admin.warehouse.detailstockadjustment.fromlocationname                                  = From Location Name
 admin.warehouse.detailstockadjustment.tolocationname                                    = To Location Name
 

--- a/model/entity/VendorOrder.cfc
+++ b/model/entity/VendorOrder.cfc
@@ -230,6 +230,25 @@ component entityname="SlatwallVendorOrder" table="SwVendorOrder" persistent="tru
 		return variables.addVendorOrderItemSkuOptionsSmartList;
 	}
 
+	public any function getAddVendorOrderItemAllSkuOptionsSmartList() {
+		if(!structKeyExists(variables, "addVendorOrderItemAllSkuOptionsSmartList")) {
+			// TODO: Needs to be refactored for efficiency, retrieving productIDs assigned to vendor
+			var vendorProducts = ormExecuteQuery("SELECT aslatwallvendor.products FROM SlatwallVendor aslatwallvendor WHERE aslatwallvendor.vendorID = :vendorID", {vendorID = getVendor().getVendorID()});
+			var vendorProductIDs = "";
+			for (var product in vendorProducts) {
+				vendorProductIDs = listAppend(vendorProductIDs, "'#product.getProductID()#'");
+			}
+
+			// Excluding the skus/products that already assigned to vendor
+			variables.addVendorOrderItemAllSkuOptionsSmartList = getService("skuService").getSkuSmartList();
+			if (len(vendorProductIDs)) {
+				variables.addVendorOrderItemAllSkuOptionsSmartList.addWhereCondition("aslatwallsku.product.productID NOT IN ( #vendorProductIDs# )");
+			}
+			variables.addVendorOrderItemAllSkuOptionsSmartList.addOrder('skuCode|ASC');
+		}
+		return variables.addVendorOrderItemAllSkuOptionsSmartList;
+	}
+
 
 	// ============  END:  Non-Persistent Property Methods =================
 

--- a/model/entity/VendorOrder.cfc
+++ b/model/entity/VendorOrder.cfc
@@ -232,18 +232,9 @@ component entityname="SlatwallVendorOrder" table="SwVendorOrder" persistent="tru
 
 	public any function getAddVendorOrderItemAllSkuOptionsSmartList() {
 		if(!structKeyExists(variables, "addVendorOrderItemAllSkuOptionsSmartList")) {
-			// TODO: Needs to be refactored for efficiency, retrieving productIDs assigned to vendor
-			var vendorProducts = ormExecuteQuery("SELECT aslatwallvendor.products FROM SlatwallVendor aslatwallvendor WHERE aslatwallvendor.vendorID = :vendorID", {vendorID = getVendor().getVendorID()});
-			var vendorProductIDs = "";
-			for (var product in vendorProducts) {
-				vendorProductIDs = listAppend(vendorProductIDs, "'#product.getProductID()#'");
-			}
-
 			// Excluding the skus/products that already assigned to vendor
 			variables.addVendorOrderItemAllSkuOptionsSmartList = getService("skuService").getSkuSmartList();
-			if (len(vendorProductIDs)) {
-				variables.addVendorOrderItemAllSkuOptionsSmartList.addWhereCondition("aslatwallsku.product.productID NOT IN ( #vendorProductIDs# )");
-			}
+			variables.addVendorOrderItemAllSkuOptionsSmartList.addWhereCondition("aslatwallsku.product NOT IN ( SELECT aslatwallproduct FROM SlatwallVendor aslatwallvendor JOIN aslatwallvendor.products aslatwallproduct WHERE aslatwallvendor.vendorID = :vendorID )", {vendorID = getVendor().getVendorID()});
 			variables.addVendorOrderItemAllSkuOptionsSmartList.addOrder('skuCode|ASC');
 		}
 		return variables.addVendorOrderItemAllSkuOptionsSmartList;

--- a/model/service/VendorOrderService.cfc
+++ b/model/service/VendorOrderService.cfc
@@ -58,6 +58,7 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 	property name="stockService" type="any";
 	property name="taxService" type="any";
 	property name="typeService" type="any";
+	property name="vendorService" type="any";
 	
 	// ===================== START: Logical Methods ===========================
 	
@@ -231,6 +232,22 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 	
 	public any function processVendorOrder_receive(required any vendorOrder, required any processObject){
 		
+		// Automatically keep preference history of vendor and product/sku for future convenience
+		var newVendorProductPreferenceFlag = false;
+		for (var vendorOrderItem in arguments.vendorOrder.getVendorOrderItems()) {
+			var product = vendorOrderItem.getSku().getProduct();
+			if (!arguments.vendorOrder.getVendor().hasProduct(product)) {
+				// Add vendor product relationship
+				arguments.vendorOrder.getVendor().addProduct(product);
+				newVendorProductPreferenceFlag = true;
+			}
+		}
+
+		// Persist update vendor products if necessary
+		if (newVendorProductPreferenceFlag) {
+			getVendorService().saveVendor(arguments.vendorOrder.getVendor());
+		}
+
 		var stockReceiver = getStockService().newStockReceiver();
 		stockReceiver.setReceiverType( "vendorOrder" );
 		stockReceiver.setVendorOrder( arguments.vendorOrder );


### PR DESCRIPTION
Allows vendor orders to be populated with items that do not have an existing vendor/product relationship assigned. Any item added without that relationship will automatically create a vendor/product relationship when the vendor order is received. Keeps a vendor/product preference history.