### PR TITLE
Property in location typeahead that allows user to ignore parent locations

### DIFF
--- a/admin/views/entity/preprocessorder_addorderitem.cfm
+++ b/admin/views/entity/preprocessorder_addorderitem.cfm
@@ -228,7 +228,7 @@ Notes:
 
 									<!--- Pickup Fulfillment Details --->
 									<hb:HibachiDisplayToggle selector="select[name='fulfillmentMethodID']" valueAttribute="fulfillmentmethodtype" showValues="pickup" loadVisable="#loadFulfillmentMethodType eq 'pickup'#">
-										<swa:SlatwallLocationTypeahead locationPropertyName="pickupLocationID" locationLabelText="#rc.$.slatwall.rbKey('entity.orderFulfillment.pickupLocation')#" edit="true" showActiveLocationsFlag="true"></swa:SlatwallLocationTypeahead>
+										<swa:SlatwallLocationTypeahead locationPropertyName="pickupLocationID" locationLabelText="#rc.$.slatwall.rbKey('entity.orderFulfillment.pickupLocation')#" edit="true" showActiveLocationsFlag="true" ignoreParentLocationsFlag="true"></swa:SlatwallLocationTypeahead>
 										
 										
 									</hb:HibachiDisplayToggle>

--- a/tags/SlatwallLocationTypeahead.cfm
+++ b/tags/SlatwallLocationTypeahead.cfm
@@ -5,6 +5,7 @@
 <cfparam name="attributes.rbKey" type="string" default="entity.location" />		<!--- entity.location --->
 <cfparam name="attributes.selectedFormatString" type="string" default="Store Locations >> ${locationName}"/><!--- Store Locations >> ${locationName} --->
 <cfparam name="attributes.showActiveLocationsFlag" type="boolean" default="false" />
+<cfparam name="attributes.ignoreParentLocationsFlag" type="boolean" default="false" />
 <cfparam name="attributes.maxrecords" type="string" default="25" />
 <cfif thisTag.executionMode is "start">
 	<cfoutput>
@@ -56,11 +57,27 @@
 					            data-collection-config-property="typeaheadCollectionConfig"
 					            data-parent-directive-controller-as-name="swTypeaheadInputField"
 					            data-all-records="true">
+					    	
+					    								<!--- Columns --->
+ 							<sw-collection-columns>
+ 								<sw-collection-column data-property-identifier="locationName" is-searchable="true"></sw-collection-column>
+ 								<sw-collection-column data-property-identifier="locationID" is-searchable="false"></sw-collection-column>
+ 							</sw-collection-columns>
+ 							
+ 							<!--- Order By --->
+ 					    	<sw-collection-order-bys>
+ 					        	<sw-collection-order-by data-order-by="locationName|ASC"></sw-collection-order-by>
+ 					    	</sw-collection-order-bys>
 
 					    	<!--- Filters --->
-					    	<cfif attributes.showActiveLocationsFlag EQ true>
+					    	<cfif attributes.showActiveLocationsFlag EQ true OR attributes.ignoreParentLocationsFlag EQ true>
 						    	<sw-collection-filters>
-		                            <sw-collection-filter data-property-identifier="activeFlag" data-comparison-operator="=" data-comparison-value="1"></sw-collection-filter>
+		                            <cfif attributes.showActiveLocationsFlag EQ true>	
+		                            	<sw-collection-filter data-property-identifier="activeFlag" data-comparison-operator="=" data-comparison-value="1"></sw-collection-filter>
+		                        	</cfif>
+		                        	<cfif attributes.ignoreParentLocationsFlag EQ true>
+		                        		<sw-collection-filter data-property-identifier="parentLocation" data-comparison-operator="is not" data-comparison-value="null"></sw-collection-filter>
+		                        	</cfif>
 		                        </sw-collection-filters>
 					    	</cfif>
 					    </sw-collection-config>


### PR DESCRIPTION
Had to revert some old slatwall changes (ten24/slatwall@0640a41#diff-339a8a8a2f77b2b647e26f5d89abdde0) to make collection filters work. 