### PR TITLE
Updates Promo service

### DIFF
--- a/model/service/PromotionService.cfc
+++ b/model/service/PromotionService.cfc
@@ -1351,9 +1351,9 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 			arguments.promotionPeriod.setEndDateTime(arguments.processObject.getEndDateTime());
 		}
 		
-		var promotionPeriod = this.savePromotionPeriod(arguments.promotionPeriod);
+		this.savePromotionPeriod(arguments.promotionPeriod);
 
-		return promotionPeriod;
+		return arguments.promotionPeriod;
 	}
 
 	// =====================  END: Process Methods ============================


### PR DESCRIPTION
Save is passed by reference so no need to return and it throws an error because promotion period is already defined in variables scope.