### PR TITLE
Fix order item gift recipient getting set twice

### DIFF
--- a/model/service/OrderService.cfc
+++ b/model/service/OrderService.cfc
@@ -682,7 +682,6 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 		}
 
 		// Persist relationship between orderItem and orderItemGiftRecipient
-		orderItemGiftRecipient.setOrderItem(orderItem);
         orderItemGiftRecipient = this.saveOrderItemGiftRecipient(orderItemGiftRecipient);
 
 		// Save order


### PR DESCRIPTION
The issue doesn't persist, but the response for that request contains duplicate Order Item Gift Recipients. This fixes that.

Shouldn't be an issue as if you haven't already set the order item on the orderItemGiftRecipient you will fail validation in hibachiService's process() method.