### PR TITLE
remove the logic creating the key on init

### DIFF
--- a/model/service/EncryptionService.cfc
+++ b/model/service/EncryptionService.cfc
@@ -52,9 +52,7 @@ component output="false" accessors="true" extends="HibachiService" {
 	
 	public any function init(any settingService=getService('settingService')) {
 		setSettingService(settingService);
-		if(!encryptionKeyExists()){
-			createEncryptionKey();
-		}
+		
 		return super.init();
 	}
 	


### PR DESCRIPTION
Found by Sumit: The init method is recreating the legacy key file.
The new encyption key logic checks if that file exists, if it does, it copies the contents into the new encryption file as a legacy key. And the new encryption key file grows larger and larger. 