### PR TITLE
Fixed issue with detailvendororder displaying duplicate vendor orders

### DIFF
--- a/model/service/VendorOrderService.cfc
+++ b/model/service/VendorOrderService.cfc
@@ -75,6 +75,7 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 	public any function getStockReceiverSmartList(string vendorOrderID) {
 		var smartList = getStockService().getStockReceiverSmartlist();	
 		smartList.addFilter("stockReceiverItems.vendorOrderItem.vendorOrder.vendorOrderID", arguments.vendorOrderID);
+		smartList.setSelectDistinctFlag(true);
 		return smartList;
 	}
 	


### PR DESCRIPTION
Fixed issue with detailvendororder displaying duplicate vendor orders if vendor order items partially received.