### PR TITLE
Develop team ih core orderfulfillmentpickuplocation

### DIFF
--- a/admin/client/src/fulfillmentbatch/components/fulfillmentbatchdetail.html
+++ b/admin/client/src/fulfillmentbatch/components/fulfillmentbatchdetail.html
@@ -14,7 +14,9 @@
 			data-collection-config="swFulfillmentBatchDetailController.state.lgFulfillmentBatchItemCollection"
 			data-edit="true"
 			data-has-search="true"
-			data-record-detail-action="admin:entity.detailfulfillmentBatchItem"
+			data-record-detail-action="admin:entity.detailorderfulfillment"
+			data-record-detail-action-id-property="orderFulfillmentID"
+			data-record-detail-action-id-key="orderFulfillment_orderFulfillmentID"
 			data-is-angular-route="false"
 			data-angular-links="true"
 			data-has-action-bar="true" 
@@ -41,7 +43,9 @@
 			data-collection-config="swFulfillmentBatchDetailController.state.smFulfillmentBatchItemCollection"
 			data-edit="true"
 			data-has-search="false"
-			data-record-detail-action="admin:entity.detailfulfillmentBatchItem"
+			data-record-detail-action="admin:entity.detailorderfulfillment"
+			data-record-detail-action-id-property="orderFulfillmentID"
+			data-record-detail-action-id-key="orderFulfillment_orderFulfillmentID"
 			data-is-angular-route="false"
 			data-angular-links="true"
 			data-has-action-bar="true" 
@@ -244,8 +248,8 @@
                                     	<div class="col-md-2">&nbsp</div>
                                         <div class="col-md-2"><strong>Item Name</strong></div>
                                         <div class="col-md-2"><strong>Sku Code</strong></div>
+					<div class="col-md-2"><strong>Qty Ordered</strong></div>
                                         <div class="col-md-2"><strong>Qty Delivered</strong></div>
-                                        <div class="col-md-2"><strong>Qty Ordered</strong></div>
                                         <div class="col-md-2">&nbsp</div>
                                     </div><br>
                                     <span ng-init="swFulfillmentBatchDetailController.orderItem = {}"></span>
@@ -261,9 +265,9 @@
                                            
                                            <div class="col-md-2">{{oi['sku_skuCode']}}</div>
                                            
-                                           <div class="col-md-2">{{oi.quantityDelivered}}</div>
-                                           
                                            <div class="col-md-2">{{oi.quantity}}</div>
+                                           
+                                           <div class="col-md-2">{{oi.quantityDelivered}}</div>
                                            
                                            <div class="col-md-2">
                                             	<input type="text" name="orderItemQuantity_{{oi.orderItemID}}" class="form-control" ng-model="swFulfillmentBatchDetailController.orderItem[oi.orderItemID]" ng-disabled="swFulfillmentBatchDetailController.state.currentRecordOrderDetail['orderFulfillmentStatusType_typeName'] == 'Fulfilled'"/>
@@ -492,7 +496,7 @@
                 </div>
                 
                 <!--- Start Custom Attributes --->
-                <div class="s-detail-body s-arrow">
+                <div class="s-detail-body s-arrow" ng-if="swFulfillmentBatchDetailController.state.orderDeliveryAttributes && swFulfillmentBatchDetailController.state.orderDeliveryAttributes.length">
                     <div class="s-content-block-wrapper">
                         <div class="s-header">
                             <h3>Order Delivery Custom Properties <i class="fa fa-info-circle s-tooltip-hint"></i></h3>

--- a/admin/client/src/orderfulfillment/components/orderfulfillmentlist.html
+++ b/admin/client/src/orderfulfillment/components/orderfulfillmentlist.html
@@ -40,15 +40,15 @@
 																						<sw-typeahead-input-field
 																								data-entity-name="Location"
 																						        data-property-to-save="locationID"
-																						        data-property-to-show="locationPathName"
-																						        data-properties-to-load="locationID,locationPathName,primaryAddress.address.city,primaryAddress.address.stateCode,primaryAddress.address.postalCode"
+																						        data-property-to-show="calculatedLocationPathName"
+																						        data-properties-to-load="locationID,calculatedLocationPathName,primaryAddress.address.city,primaryAddress.address.stateCode,primaryAddress.address.postalCode"
 																						        data-show-add-button="true"
 																						        data-show-view-button="true"
 																						        data-placeholder-rb-key="entity.location"
 																						        data-placeholder-text="Stock Location"
 																						        data-multiselect-mode="false"
 																						        data-filter-flag="true"
-																						        data-selected-format-string="${locationPathName}&nbsp;"
+																						        data-selected-format-string="${calculatedLocationPathName}&nbsp;"
 																						        data-field-name="locationID">
 																						
 																						    <sw-collection-config
@@ -63,18 +63,18 @@
 																							        <sw-collection-column data-property-identifier="primaryAddress.address.city" data-is-searchable="true"></sw-collection-column>
 																							        <sw-collection-column data-property-identifier="primaryAddress.address.stateCode" data-is-searchable="true"></sw-collection-column>
 																							        <sw-collection-column data-property-identifier="primaryAddress.address.postalCode" data-is-searchable="true"></sw-collection-column>
-																							        <sw-collection-column data-property-identifier="locationPathName" data-is-searchable="true"></sw-collection-column>
+																							        <sw-collection-column data-property-identifier="calculatedLocationPathName" data-is-searchable="true"></sw-collection-column>
 																							        <sw-collection-column data-property-identifier="locationID"></sw-collection-column>
 																							    </sw-collection-columns>
 																								
 																						    	<sw-collection-order-bys>
-																						        	<sw-collection-order-by data-order-by="locationPathName|ASC"></sw-collection-order-by>
+																						        	<sw-collection-order-by data-order-by="calculatedLocationPathName|ASC"></sw-collection-order-by>
 																						    	</sw-collection-order-bys>
 																						
 																						    </sw-collection-config>
 																							
 																							    
-																							    <span sw-typeahead-search-line-item data-property-identifier="locationPathName"></span><br>
+																							    <span sw-typeahead-search-line-item data-property-identifier="calculatedLocationPathName"></span><br>
 																							    	
 																						</sw-typeahead-input-field>
 																						<!--- VIEW CHANGE: No location selected --->
@@ -159,7 +159,7 @@
 																		        data-placeholder-text="Select Account"
 																		        data-multiselect-mode="false"
 																		        data-filter-flag="true"
-																		        data-selected-format-string="${lastName}&nbsp;"
+																		        data-selected-format-string="${lastName}&nbsp;${firstName}"
 																		        data-field-name="accountID">
 																			<!-- end ngIf: swTypeaheadSearch.placeholderText -->
 																		    <sw-collection-config
@@ -181,7 +181,7 @@
 																		
 																		    </sw-collection-config>
 																			
-																			    <span sw-typeahead-search-line-item data-property-identifier="lastName"></span><br>
+																			    <span sw-typeahead-search-line-item data-property-identifier="lastName">&nbsp;</span><span sw-typeahead-search-line-item data-property-identifier="firstName">&nbsp;</span><br>
 																			    	
 																		</sw-typeahead-input-field>
 																			
@@ -228,133 +228,7 @@
 			
 			<div class="row s-detail-modules-wrapper">
 				
-				<div class="col-sm-6 col-md-6 col-lg-4 s-detail-module">
-			        
-					<!--Small content block-->
-			        <div class="s-sm-content-block">
-						
-						<div class="dropdown s-action">
-							<a href="##" class="dropdown-toggle" id="changeThisLabel1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-								<i class="fa fa-ellipsis-h" title="actions"></i>
-							</a>
-							<ul class="dropdown-menu pull-right" aria-labelledby="changeThisLabel1">
-								<li>
-									<a href="##" id="j-toggle-location-1">Multi Location View</a>
-								</li>
-							</ul>
-						</div>
-						
-			            <div class="col-xs-1 col-sm-1 col-md-2 col-lg-2 s-icon">
-			                <i class="fa fa-building-o"></i>
-			            </div>
-			            <div class="col-xs-11 col-sm-11 col-md-10 col-lg-10 s-content">
-
-
-							<!--- Single Location Picker  --->
-							<div class="s-select-list-wrapper s-search" id="j-single-location-view-1">
-							    
-							        <!-- Option select field wrapper -->
-							        <div>
-							            
-										<sw-typeahead-input-field
-											data-entity-name="Location"
-									        data-property-to-save="locationID"
-									        data-property-to-show="locationPathName"
-									        data-properties-to-load="locationID,locationPathName,primaryAddress.address.city,primaryAddress.address.stateCode,primaryAddress.address.postalCode"
-									        data-show-add-button="true"
-									        data-show-view-button="true"
-									        data-placeholder-rb-key="entity.location"
-									        data-placeholder-text="Stock Location"
-									        data-multiselect-mode="true"
-									        data-filter-flag="true"
-									        data-selected-format-string="${locationPathName}&nbsp;" 
-									        data-field-name="locationIDfilter">
-										
-									    <sw-collection-config
-									            data-entity-name="Location"
-									            data-collection-config-property="typeaheadCollectionConfig"
-									            data-parent-directive-controller-as-name="swTypeaheadInputField"
-									            data-all-records="false"
-									            data-page-show="50">
-									
-											<sw-collection-columns>
-										        <sw-collection-column data-property-identifier="primaryAddress.address.addressID"></sw-collection-column>
-										        <sw-collection-column data-property-identifier="primaryAddress.address.city" data-is-searchable="true"></sw-collection-column>
-										        <sw-collection-column data-property-identifier="primaryAddress.address.stateCode" data-is-searchable="true"></sw-collection-column>
-										        <sw-collection-column data-property-identifier="primaryAddress.address.postalCode" data-is-searchable="true"></sw-collection-column>
-										        <sw-collection-column data-property-identifier="locationPathName" data-is-searchable="true"></sw-collection-column>
-										        <sw-collection-column data-property-identifier="locationID"></sw-collection-column>
-										    </sw-collection-columns>
-											
-									    	<sw-collection-order-bys>
-									        	<sw-collection-order-by data-order-by="locationPathName|ASC"></sw-collection-order-by>
-									    	</sw-collection-order-bys>
-									
-									    </sw-collection-config>
-										
-										    
-										    <span sw-typeahead-search-line-item data-property-identifier="locationPathName"></span><br>
-										    	
-									</sw-typeahead-input-field>
-							        </div>
-							</div>
-							
-							<!--- Multi Location Picker  --->
-							<div class="s-select-list-wrapper s-search ng-hide" id="j-multi-locaction-view-1">
-							    <div class="form-group">
-							        <!-- Option select field wrapper -->
-							        <div class="input-group">
-							            <div class="s-input-btn">
-							                <input id="searchinput" type="search" class="form-control" placeholder="Add Location...">
-							                <!-- <span class="glyphicon glyphicon-remove"></span> -->
-											<i class="fa fa-search"></i>
-							                <!--<i class="fa fa-refresh fa-spin"></i>--><!-- Loading Icon -->
-							            </div>
-							            <div class="input-group-btn">
-							                <button class="btn btn-sm btn-default" type="submit"><i class="fa fa-caret-down"></i></button>
-							            </div>
-							        </div>
-							    </div>
-								
-							    <!-- Dropdown wrapper -->
-							    <div class="dropdown s-search-results-wrapper" style="display: none;">
-							        <ul class="dropdown-menu">
-										<li class="s-index-0" data-group="las-angeles"><a href="##">Las Angeles</a></li>
-							            <li class="s-index-1" data-group="las-angeles"><a href="##">Hollywood</a></li>
-										<li class="s-index-1" data-group="las-angeles"><a href="##">Venice</a></li>
-							            <li class="s-index-0" data-group="san-diego"><a href="##">San Diego</a></li>
-							            <li class="s-index-1" data-group="san-diego"><a href="##">Encinitas Warehouse</a></li>
-										<li class="s-index-2" data-group="san-diego"><a href="##">843 Moonlight</a></li>
-										<li class="s-index-3" data-group="san-diego"><a href="##">Room 23</a></li>
-										<li class="s-index-3" data-group="san-diego"><a href="##">Room 45</a></li>
-										<li class="s-index-4" data-group="san-diego"><a href="##">Row 3 with really long title to show what it would do </a></li>
-							            <li class="s-index-1" data-group="san-diego"><a href="##">Del Mar Warehouse</a></li>
-							            <li class="s-index-1" data-group="san-diego"><a href="##">Carlsbad Warehouse</a></li>
-										<li class="s-index-0" data-group="boston"><a href="##">Boston</a></li>
-							        </ul>
-							    </div>
-								
-								<div class="s-selected-list">
-							        <!-- Selected options wrapper -->
-							        <div class="alert s-selected-item" title="San Diego > Encinitas Warehouse > 843 Moonlight > Room 23">
-							            <!-- Example Item 2 -->
-							            <button type="button" class="close"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button>
-							            San Diego... <strong>Room 23</strong>
-							        </div>
-									<div class="alert s-selected-item" title="San Diego > Encinitas Warehouse > 843 Moonlight > Room 48">
-							            <!-- Example Item 2 -->
-							            <button type="button" class="close"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button>
-							            San Diego... <strong>Room 48</strong>
-							        </div>
-							    </div>
-								
-							</div>
-							
-			            </div>
-						
-			        </div>
-
-			    </div>
+				
 				
 				<!--- ITEMS MODULE --->
 				<div class="col-sm-6 col-md-6 col-lg-2 s-detail-module">
@@ -393,7 +267,10 @@
 			        </div>
 			        
 			    </div>
-				
+				<div class="col-sm-6 col-md-6 col-lg-4 s-detail-module">
+			    
+
+			    </div>
 				<!--- AVAILBALE MODULE --->
 			    <!---<div class="col-sm-6 col-md-4 col-lg-2 s-detail-module s-md-content-block s-click" ng-click="swOrderFulfillmentListController.toggleFilter('available');">
 					
@@ -537,11 +414,4 @@
 			
 		</div>	
 	</div>
-<section>			
-
-
-
-
-
-
-
+<section>

--- a/admin/views/entity/preprocessorderfulfillment_fulfillitems.cfm
+++ b/admin/views/entity/preprocessorderfulfillment_fulfillitems.cfm
@@ -74,7 +74,7 @@ Notes:
 				<!--- Location --->
 
 				<cfif rc.orderFulfillment.getFulfillmentMethod().getFulfillmentMethodType() eq "pickup">
-					<swa:SlatwallLocationTypeahead property="#rc.order.getPickupLocation()#" locationPropertyName="location.locationID"  locationLabelText="#$.slatwall.rbKey('entity.location')#" edit="#rc.edit#" showActiveLocationsFlag="true" ></swa:SlatwallLocationTypeahead>
+					<swa:SlatwallLocationTypeahead property="#rc.orderFulfillment.getPickupLocation()#" locationPropertyName="location.locationID"  locationLabelText="#$.slatwall.rbKey('entity.location')#" edit="#rc.edit#" showActiveLocationsFlag="true" ></swa:SlatwallLocationTypeahead>
 				</cfif>
 				<hr />
 

--- a/org/Hibachi/client/src/listing/components/listingdisplay.html
+++ b/org/Hibachi/client/src/listing/components/listingdisplay.html
@@ -23,6 +23,7 @@
                     data-show-export="swListingDisplay.showExport"
                     data-show-toggle-search="swListingDisplay.showSearch"
                     data-show-print-options="swListingDisplay.showPrintOptions"
+                    data-show-toggle-display-options="swListingDisplay.showToggleDisplayOptions"
                     data-simple="swListingDisplay.showSimpleListingControls"
                     data-ng-if="swListingDisplay.hasSearch !== false">
 
@@ -220,18 +221,32 @@
                                 </span>
 
                                 <!-- Detail -->
-                                <sw-action-caller
-                                        ng-if="swListingDisplay.recordDetailAction && swListingDisplay.recordDetailAction.length"
-                                        data-action="{{swListingDisplay.recordDetailAction}}"
-                                        data-query-string="{{'&'+swListingDisplay.exampleEntity.$$getIDName()+'='+pageRecord[swListingDisplay.exampleEntity.$$getIDName()]+swListingDisplay.recordDetailQueryString}}"
-                                        data-class="btn btn-default btn-xs"
-                                        data-icon="eye-open"
-                                        data-iconOnly="true"
-                                        data-modal="swListingDisplay.recordDetailModal"
-                                        data-is-angular-route="swListingDisplay.isAngularRoute"
-                                >
-                                </sw-action-caller>
-
+                                <span ng-if="swListingDisplay.recordDetailActionIdProperty && swListingDisplay.recordDetailActionIdKey">
+                                    <sw-action-caller
+                                            ng-if="swListingDisplay.recordDetailAction && swListingDisplay.recordDetailAction.length"
+                                            data-action="{{swListingDisplay.recordDetailAction}}"
+                                            data-query-string="{{'&'+swListingDisplay.recordDetailActionIdProperty+'='+pageRecord[swListingDisplay.recordDetailActionIdKey]+swListingDisplay.recordDetailQueryString}}"
+                                            data-class="btn btn-default btn-xs"
+                                            data-icon="eye-open"
+                                            data-iconOnly="true"
+                                            data-modal="swListingDisplay.recordDetailModal"
+                                            data-is-angular-route="swListingDisplay.isAngularRoute"
+                                    >
+                                    </sw-action-caller>
+                                </span>
+                                <span ng-if="!swListingDisplay.recordDetailActionIdProperty || !swListingDisplay.recordDetailActionIdKey">
+                                    <sw-action-caller
+                                            ng-if="swListingDisplay.recordDetailAction && swListingDisplay.recordDetailAction.length"
+                                            data-action="{{swListingDisplay.recordDetailAction}}"
+                                            data-query-string="{{'&'+swListingDisplay.exampleEntity.$$getIDName()+'='+pageRecord[swListingDisplay.exampleEntity.$$getIDName()]+swListingDisplay.recordDetailQueryString}}"
+                                            data-class="btn btn-default btn-xs"
+                                            data-icon="eye-open"
+                                            data-iconOnly="true"
+                                            data-modal="swListingDisplay.recordDetailModal"
+                                            data-is-angular-route="swListingDisplay.isAngularRoute"
+                                    >
+                                    </sw-action-caller>
+                                </span>
                                 <span ng-if="swListingDisplay.multiSlot">
                                     <div ng-transclude="detailAction"></div>
                                 </span>

--- a/org/Hibachi/client/src/listing/components/swlistingdisplay.ts
+++ b/org/Hibachi/client/src/listing/components/swlistingdisplay.ts
@@ -61,13 +61,14 @@ class SWListingDisplayController{
     public processObjectProperties;
     public recordAddAction:string;
     public recordDetailAction:string;
+    public recordDetailActionIdProperty:string;
+    public recordDetailActionIdKey:string;
     public recordDetailActionProperty:string;
     public recordEditAction:string;
     public recordDeleteAction:string;
     public recordProcessButtonDisplayFlag:boolean;
     public searching:boolean = false;
     public searchText;
-
     public selectFieldName;
     public selectable:boolean = false;
     public showOrderBy:boolean;
@@ -77,6 +78,7 @@ class SWListingDisplayController{
     public showSearchFilters = false;
     public showTopPagination:boolean;
     public showFilters:boolean;
+    public showToggleDisplayOptions:boolean;
     public sortable:boolean = false;
     public sortableFieldName:string;
     public sortProperty;
@@ -355,8 +357,8 @@ class SWListingDisplayController{
         if(angular.isUndefined(this.showPrintOptions)){
             this.showPrintOptions = false; 
         }
-        if(angular.isUndefined(this.showPrintOptions)){
-            this.showPrintOptions = false; 
+        if(angular.isUndefined(this.showToggleDisplayOptions)){
+            this.showToggleDisplayOptions = true; 
         }
         if(angular.isUndefined(this.expandable)){
             this.expandable = false;
@@ -634,6 +636,8 @@ class SWListingDisplay implements ng.IDirective{
             recordEditDisabled:"<?",
             recordDetailAction:"@?",
             recordDetailActionProperty:"@?",
+            recordDetailActionIdProperty:"@?",
+            recordDetailActionIdKey:"@?",
             recordDetailQueryString:"@?",
             recordDetailModal:"<?",
             recordDeleteAction:"@?",
@@ -699,6 +703,7 @@ class SWListingDisplay implements ng.IDirective{
             showExport:"<?",
             showOrderBy:"<?",
             showTopPagination:"<?",
+            showToggleDisplayOptions:"<?",
             showSearch:"<?",
             showSearchFilters:"<?",
             showSimpleListingControls:"<?",


### PR DESCRIPTION
A number of small changes based on core changes in custom project.

Adds functionality to the listing display so we can define the detail action as a different entity and id.
There is an example of how I'm using it in the fulfillment batch detail. Instead of redirecting to a batch or item, it redirects to the fulfillment using the fulfillmentID.

I updates the tabs so it doesn't show the attribute tabs when no attributes are defined.

I changed the positions of qty and qty ordered.

I fixed a path for pickup location in orderfulfillment view.

Removed the stock location filter on the orderfulfillments listing.