### PR TITLE
fix for some of the performance issues on order detail

### DIFF
--- a/admin/views/entity/detailorder.cfm
+++ b/admin/views/entity/detailorder.cfm
@@ -146,7 +146,7 @@ Notes:
 			</cfloop>
 
 			<!--- Comments --->
-			<swa:SlatwallAdminTabComments object="#rc.order#" childObjects="#rc.order.getOrderItems()#" />
+			<swa:SlatwallAdminTabComments object="#rc.order#" />
 
 		</hb:HibachiEntityDetailGroup>
 


### PR DESCRIPTION
passing in the orderitems to the comments tab slows the page load on order detail because it must load all orders items and related data.