### PR TITLE
Develop team th aws sns email parser

### DIFF
--- a/admin/controllers/aws.cfc
+++ b/admin/controllers/aws.cfc
@@ -1,0 +1,96 @@
+
+/*
+
+    Slatwall - An Open Source eCommerce Platform
+    Copyright (C) ten24, LLC
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    Linking this program statically or dynamically with other modules is
+    making a combined work based on this program.  Thus, the terms and
+    conditions of the GNU General Public License cover the whole
+    combination.
+
+    As a special exception, the copyright holders of this program give you
+    permission to combine this program with independent modules and your
+    custom code, regardless of the license terms of these independent
+    modules, and to copy and distribute the resulting program under terms
+    of your choice, provided that you follow these specific guidelines:
+
+	- You also meet the terms and conditions of the license of each
+	  independent module
+	- You must not alter the default display of the Slatwall name or logo from
+	  any part of the application
+	- Your custom code must not alter or create any files inside Slatwall,
+	  except in the following directories:
+		/integrationServices/
+
+	You may copy and distribute the modified version of this program that meets
+	the above guidelines as a combined work under the terms of GPL for this program,
+	provided that you include the source code of that other code when and as the
+	GNU GPL requires distribution of source code.
+
+    If you modify this program, you may extend this exception to your version
+    of the program, but you are not obligated to do so.
+
+Notes:
+
+*/
+component output="false" accessors="true" extends="Slatwall.org.Hibachi.HibachiController" {
+
+    // fw1 Auto-Injected Service Properties
+    property name="hibachiUtilityService" type="any";
+    property name="hibachiAwsService" type="any";
+
+    this.publicMethods='';
+    this.publicMethods=listAppend(this.publicMethods, 'snsReceive');
+
+    public void function before( required struct rc ) {
+        getFW().setView("public:main.blank");
+
+        // NOTE: AWS SNS sends JSON, but content-type is text/plain
+
+        arguments.rc.requestBody = getHTTPRequestData().content;
+        arguments.rc.requestPreProcessedFlag = false;
+
+        // Assume all requests contain JSON encoded body content and automatically deserialize
+        if (isJSON(arguments.rc.requestBody)) {
+            arguments.rc.requestBody = deserializeJSON(arguments.rc.requestBody);
+            arguments.rc.requestPreProcessedFlag = true;
+        
+        // Setup error response status
+        } else {
+            arguments.rc.responseStatus = {
+                statusCode = 501,
+                statusText = "Could not handle request body content. Expected JSON."
+            }
+        }
+    }
+
+    public void function after( required struct rc ) {
+        // Render all items as text/plain
+        getFW().renderer().statusCode(arguments.rc.responseStatus.statusCode).statusText(arguments.rc.responseStatus.statusText).type('text').data('');
+    }
+
+    public void function snsReceive(required struct rc) {
+        
+        if (arguments.rc.requestPreProcessedFlag) {
+            // Pass onto service as SNS payload
+            var result = getHibachiAwsService().snsReceive(snsPayload = arguments.rc.requestBody);
+
+            // Set the response status for renderer to use
+            arguments.rc.responseStatus = result.responseStatus;
+        }
+    }
+}

--- a/admin/controllers/aws.cfc
+++ b/admin/controllers/aws.cfc
@@ -80,11 +80,11 @@ component output="false" accessors="true" extends="Slatwall.org.Hibachi.HibachiC
 
     public void function after( required struct rc ) {
         // Render all items as text/plain
-        getFW().renderer().statusCode(arguments.rc.responseStatus.statusCode).statusText(arguments.rc.responseStatus.statusText).type('text').data('');
+        getFW().renderer().statusCode(arguments.rc.responseStatus.statusCode).statusText(arguments.rc.responseStatus.statusText).type('json').data({});
     }
 
     public void function snsReceive(required struct rc) {
-        
+
         if (arguments.rc.requestPreProcessedFlag) {
             // Pass onto service as SNS payload
             var result = getHibachiAwsService().snsReceive(snsPayload = arguments.rc.requestBody);

--- a/model/service/HibachiAwsService.cfc
+++ b/model/service/HibachiAwsService.cfc
@@ -1,0 +1,50 @@
+/*
+
+    Slatwall - An Open Source eCommerce Platform
+    Copyright (C) ten24, LLC
+	
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+	
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+	
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    
+    Linking this program statically or dynamically with other modules is
+    making a combined work based on this program.  Thus, the terms and
+    conditions of the GNU General Public License cover the whole
+    combination.
+	
+    As a special exception, the copyright holders of this program give you
+    permission to combine this program with independent modules and your 
+    custom code, regardless of the license terms of these independent
+    modules, and to copy and distribute the resulting program under terms 
+    of your choice, provided that you follow these specific guidelines: 
+
+	- You also meet the terms and conditions of the license of each 
+	  independent module 
+	- You must not alter the default display of the Slatwall name or logo from  
+	  any part of the application 
+	- Your custom code must not alter or create any files inside Slatwall, 
+	  except in the following directories:
+		/integrationServices/
+
+	You may copy and distribute the modified version of this program that meets 
+	the above guidelines as a combined work under the terms of GPL for this program, 
+	provided that you include the source code of that other code when and as the 
+	GNU GPL requires distribution of source code.
+    
+    If you modify this program, you may extend this exception to your version 
+    of the program, but you are not obligated to do so.
+
+Notes:
+
+*/
+component accessors="true" output="false" extends="Slatwall.org.Hibachi.HibachiAwsService" {	
+}

--- a/model/service/HibachiAwsService.cfc
+++ b/model/service/HibachiAwsService.cfc
@@ -46,5 +46,8 @@
 Notes:
 
 */
-component accessors="true" output="false" extends="Slatwall.org.Hibachi.HibachiAwsService" {	
+component accessors="true" output="false" extends="Slatwall.org.Hibachi.HibachiAwsService" {
+    public boolean function verifyAwsSignature() {
+        return true;
+    }
 }

--- a/org/Hibachi/Hibachi.cfc
+++ b/org/Hibachi/Hibachi.cfc
@@ -502,8 +502,10 @@ component extends="framework.one" {
 			}
 		}
 
-		// Setup structured Data if a request context exists meaning that a full action was called
-		getHibachiScope().getService("hibachiUtilityService").buildFormCollections(request.context);
+		// Setup structured Data if a request context exists meaning that a full action was called (excluding requests from AWS)
+		if (!structKeyExists(httpRequestData.headers, "X-Amz-Sns-Message-Id")) {
+			getHibachiScope().getService("hibachiUtilityService").buildFormCollections(request.context);
+		}
 
 		// Setup a $ in the request context, and the hibachiScope shortcut
 		request.context.fw = getHibachiScope().getApplicationValue("application");

--- a/org/Hibachi/HibachiAwsService.cfc
+++ b/org/Hibachi/HibachiAwsService.cfc
@@ -1,0 +1,79 @@
+/*
+
+    Slatwall - An Open Source eCommerce Platform
+    Copyright (C) ten24, LLC
+	
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+	
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+	
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    
+    Linking this program statically or dynamically with other modules is
+    making a combined work based on this program.  Thus, the terms and
+    conditions of the GNU General Public License cover the whole
+    combination.
+	
+    As a special exception, the copyright holders of this program give you
+    permission to combine this program with independent modules and your 
+    custom code, regardless of the license terms of these independent
+    modules, and to copy and distribute the resulting program under terms 
+    of your choice, provided that you follow these specific guidelines: 
+
+	- You also meet the terms and conditions of the license of each 
+	  independent module 
+	- You must not alter the default display of the Slatwall name or logo from  
+	  any part of the application 
+	- Your custom code must not alter or create any files inside Slatwall, 
+	  except in the following directories:
+		/integrationServices/
+
+	You may copy and distribute the modified version of this program that meets 
+	the above guidelines as a combined work under the terms of GPL for this program, 
+	provided that you include the source code of that other code when and as the 
+	GNU GPL requires distribution of source code.
+    
+    If you modify this program, you may extend this exception to your version 
+    of the program, but you are not obligated to do so.
+
+Notes:
+
+*/
+
+component extends="HibachiService" accessors="true" {
+
+    public struct function snsReceive( required struct snsPayload, struct result = {} ) {
+
+        // Response status to send back to AWS SNS
+        arguments.result.responseStatus = {statusCode = 200, statusText = "OK"}; 
+        
+        // Data received from AWS SNS
+        arguments.result.snsPayload = arguments.snsPayload;
+        
+        // Data to populate for application consumption
+        arguments.result.data = {};
+
+        if (verifyAwsSignature()) {
+
+            // Announce event with the data
+            getHibachiEventService().announceEvent(eventName="onAwsSnsReceive", eventData=arguments.result);
+        }
+
+        return arguments.result;
+    }
+
+    /**
+     * Check to prevent processing a spoofed requests
+     * TODO: Needs params specified, extend to rely on Slatwall settings within model/service/HibachiAwsService
+     */
+    public boolean function verifyAwsSignature() {
+        return true;
+    }
+}

--- a/org/Hibachi/HibachiAwsService.cfc
+++ b/org/Hibachi/HibachiAwsService.cfc
@@ -93,8 +93,8 @@ component extends="HibachiService" accessors="true" {
                         retrieveFromS3Args.objectKey = arguments.snsPayload.message.receipt.action.objectKey;
                         retrieveFromS3Args.bucketName = arguments.snsPayload.message.receipt.action.bucketName;
                         retrieveFromS3Args.objectKeyPrefix = arguments.snsPayload.message.receipt.action.objectKeyPrefix;
-                        retrieveFromS3Args.awsAccessKeyId = 'AKIAIZJJONX5S3FCSKAA';
-                        retrieveFromS3Args.awsSecretAccessKey = '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';
+                        retrieveFromS3Args.awsAccessKeyId = '';
+                        retrieveFromS3Args.awsSecretAccessKey = '';
                         retrieveFromS3Args.deleteS3ObjectAfter = false;
 
                         arguments.snsPayload.s3FileData = getHibachiUtilityService().retrieveFromS3(argumentCollection = retrieveFromS3Args);

--- a/org/Hibachi/HibachiAwsService.cfc
+++ b/org/Hibachi/HibachiAwsService.cfc
@@ -89,7 +89,15 @@ component extends="HibachiService" accessors="true" {
     
                     // Automatically retrieve S3 object if not named "AMAZON_SES_SETUP_NOTIFICATION" and not spam or a virus verdict.
                     if (structKeyExists(arguments.snsPayload.message, 'receipt') && structKeyExists(arguments.snsPayload.message.receipt, 'action') && structKeyExists(arguments.snsPayload.message.receipt.action, 'type') && arguments.snsPayload.message.receipt.action.type == 'S3') {
-                        arguments.result.data.s3FileContent = getHibachiUtilityService().retrieveFromS3();
+                        var retrieveFromS3Args = {};
+                        retrieveFromS3Args.objectKey = arguments.snsPayload.message.receipt.action.objectKey;
+                        retrieveFromS3Args.bucketName = arguments.snsPayload.message.receipt.action.bucketName;
+                        retrieveFromS3Args.objectKeyPrefix = arguments.snsPayload.message.receipt.action.objectKeyPrefix;
+                        retrieveFromS3Args.awsAccessKeyId = 'AKIAIZJJONX5S3FCSKAA';
+                        retrieveFromS3Args.awsSecretAccessKey = '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';
+                        retrieveFromS3Args.deleteS3ObjectAfter = false;
+
+                        arguments.result.data.s3FileContent = getHibachiUtilityService().retrieveFromS3(argumentCollection = retrieveFromS3Args);
                     }
                 }
 

--- a/org/Hibachi/HibachiAwsService.cfc
+++ b/org/Hibachi/HibachiAwsService.cfc
@@ -49,16 +49,16 @@ Notes:
 
 component extends="HibachiService" accessors="true" {
 
-    public struct function snsReceive( required struct snsPayload, struct result = {} ) {
+    public struct function snsReceive( required struct snsPayload ) {
+
+        var resultData = {};
+
+        // Reference to data received from AWS SNS
+        resultData.snsPayload = arguments.snsPayload;
 
         // Response status to send back to AWS SNS
-        arguments.result.responseStatus = {statusCode = 200, statusText = "OK"}; 
-        
-        // Reference to data received from AWS SNS
-        arguments.result.snsPayload = arguments.snsPayload;
-        
-        // Data to populate for application consumption
-        arguments.result.data = {};
+        responseStatus = {statusCode = 200, statusText = "OK"}; 
+        resultData.responseStatus = responseStatus; 
 
         if (verifyAwsSignature()) {
 
@@ -97,23 +97,23 @@ component extends="HibachiService" accessors="true" {
                         retrieveFromS3Args.awsSecretAccessKey = 'YFmCxa7HxtYc4yWGnPkIZwMsQdY4QpNEGymfAr21';
                         retrieveFromS3Args.deleteS3ObjectAfter = false;
 
-                        arguments.result.data.s3FileContent = getHibachiUtilityService().retrieveFromS3(argumentCollection = retrieveFromS3Args);
+                        arguments.snsPayload.s3FileData = getHibachiUtilityService().retrieveFromS3(argumentCollection = retrieveFromS3Args);
                     }
                 }
 
                 // Announce event with the data
-                getHibachiEventService().announceEvent(eventName="onAwsSnsReceive", eventData=arguments.result);
+                getHibachiEventService().announceEvent(eventName="onAwsSnsReceive", eventData=resultData);
             
             // Error further implementation required to handle notification type
             } else {
                 logHibachi("Need to further implement handling for SNS notifications of type '#snsPayload.type#'.");
-                arguments.result.responseStatus.statusCode = 501;
-                arguments.result.responseStatus.statusText = "Not implemented to handle '#snsPayload.type#'";
+                responseStatus.statusCode = 501;
+                responseStatus.statusText = "Not implemented to handle '#snsPayload.type#'";
             }
 
         }
 
-        return arguments.result;
+        return resultData;
     }
 
     /**

--- a/org/Hibachi/HibachiUtilityService.cfc
+++ b/org/Hibachi/HibachiUtilityService.cfc
@@ -1032,6 +1032,10 @@
 			fileClose(dataFile);
 		};
 
+		public any function retrieveFromS3(string objectID, string bucketName, string objectKeyPrefix, string awsAccessKeyId, string awsSecretAccessKey, string acl, string storageClass, boolean deleteS3ObjectAfter) {
+			// TODO: Need to implement
+		}
+
 	</cfscript>
 
 	<cffunction name="logException" returntype="void" access="public">


### PR DESCRIPTION
Miguel, here is some of the progress with abstracting the general AWS SNS handling logic into Hibachi/Slatwall. I'm still adding the parsing/handling pieces that I've developed first as external units since this functionality is more challenging to develop/test running within the Hibachi/Slatwall lifecycle. So I'm in the process of wiring it all up within the Hibachi/Slatwall lifecycle.

But basically once it has the SNS message deserialized and parsed into a struct (and fetching any corresponding S3 file if needed), an event is announced with the data. That way any future application with other SNS needs can leverage this boilerplate.

A custom event handler will take care of pushing the SNS data into a custom integrations services.