### PR TITLE
Update hibachiDAO

### DIFF
--- a/org/Hibachi/HibachiDAO.cfc
+++ b/org/Hibachi/HibachiDAO.cfc
@@ -199,7 +199,7 @@
 									arrayAppend(successfulEntities,trim(entityData['entityQueueID']));
 								}catch(any e){
 									//if failed then log the recent failure
-									ORMExecuteQuery('UPDATE SlatwallEntityQueue SET mostRecentError=:mostRecentError WHERE entityQueueID=:entityQueueID',{entityQueueID=trim(entityData['entityQueueID']),mostRecentError=e.mesage & ' - ' &e.detail});
+									ORMExecuteQuery('UPDATE SlatwallEntityQueue SET mostRecentError=:mostRecentError WHERE entityQueueID=:entityQueueID',{entityQueueID=trim(entityData['entityQueueID']),mostRecentError=e.message & ' - ' &e.detail});
 								}
 								
 				    		}


### PR DESCRIPTION
Typo is causing whole threaded section of code to throw each time it uses that logic. The entity queue can't be cleared out because of that.