### PR TITLE
Updates WorkflowService

### DIFF
--- a/model/service/WorkflowService.cfc
+++ b/model/service/WorkflowService.cfc
@@ -121,7 +121,7 @@ component extends="HibachiService" accessors="true" output="false" {
 		var allWorkflowTriggerEventsArray = getHibachiCacheService().getOrCacheFunctionValue("workflowDAO_getWorkflowTriggerEventsArray", getWorkflowDAO(), "getWorkflowTriggerEventsArray");
 		
 		// Make sure that this event has workflows attached before creating a thread
-		if(arrayFind(allWorkflowTriggerEventsArray, arguments.eventName)) {
+		if(arrayFindNoCase(allWorkflowTriggerEventsArray, arguments.eventName)) {
 			
 			// Run all workflows inside of a thread
 			//thread action="run" name="#createUUID()#" application="#application#" eventName="#arguments.eventName#" entity="#arguments.entity#" {


### PR DESCRIPTION
Workflow emails were not going out because the casing of events will not always match when using arrayFind instead of arrayFindNoCase. In my example, cancelorder was not firing because it was cased as cancelorder instead of cancelOrder.