### PR TITLE
Added logic to force Aggregates to use STR func

### DIFF
--- a/model/entity/Collection.cfc
+++ b/model/entity/Collection.cfc
@@ -3526,7 +3526,7 @@ component displayname="Collection" entityname="SlatwallCollection" table="SwColl
 					&& column.ormtype neq 'big_decimal')
 				) continue;
 
-				var formatter = (column.ormtype eq 'big_decimal' || column.ormtype eq 'integer') ? 'STR' : '';
+				var formatter = (column.ormtype eq 'big_decimal' || column.ormtype eq 'integer' || structKeyExists(column, 'aggregate') ) ? 'STR' : '';
 				if(formatter == '' && getHibachiScope().getApplicationValue('databaseType')=="Oracle10g"){
 					formatter = "LOWER";
 				}


### PR DESCRIPTION
This is to prevent the "string cannot be converted to a number" error when trying to filter in collections

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ten24/slatwall/6486)
<!-- Reviewable:end -->
