### PR TITLE
file upload enhancement

### DIFF
--- a/org/Hibachi/HibachiTransient.cfc
+++ b/org/Hibachi/HibachiTransient.cfc
@@ -177,7 +177,7 @@ component output="false" accessors="true" persistent="false" extends="HibachiObj
 	}
 
 	// @hint Public populate method to utilize a struct of data that follows the standard property form format
-	public any function populate( required struct data={} ) {
+	public any function populate( required struct data={}, formUploadDottedPath="" ) {
 
 		// Call beforePopulate
 		beforePopulate(data=arguments.data);
@@ -265,7 +265,7 @@ component output="false" accessors="true" persistent="false" extends="HibachiObj
 							_setProperty(currentProperty.name, thisEntity );
 
 							// Populate the sub property
-							thisEntity.populate(manyToOneStructData);
+							thisEntity.populate(manyToOneStructData, '#arguments.formUploadDottedPath##currentProperty.name#.');
 
 							// Tell the variables scope that we populated this sub-property
 							addPopulatedSubProperty(currentProperty.name, thisEntity);
@@ -324,7 +324,7 @@ component output="false" accessors="true" persistent="false" extends="HibachiObj
 							if(structCount(oneToManyArrayData[a]) gt 1) {
 
 								// Populate the sub property
-								thisEntity.populate(oneToManyArrayData[a]);
+								thisEntity.populate(oneToManyArrayData[a], '#arguments.formUploadDottedPath##currentProperty.name#[#a#].');
 
 								addPopulatedSubProperty(currentProperty.name, thisEntity);
 							}
@@ -393,6 +393,7 @@ component output="false" accessors="true" persistent="false" extends="HibachiObj
 			
 			
 			// Check to see if we should upload this property
+			// Prepend the provided formUploadDottedPath if this file is being uploaded as a subpopulated property to determine absolute path reference for form scope retrieval
 			if( 
 				structKeyExists(arguments.data, currentProperty.name) 
 				&& (
@@ -403,8 +404,8 @@ component output="false" accessors="true" persistent="false" extends="HibachiObj
 				&& currentProperty.hb_fileUpload 
 				&& structKeyExists(currentProperty, "hb_fileAcceptMIMEType") 
 				&& len(arguments.data[ currentProperty.name ]) 
-				&& structKeyExists(form, currentProperty.name) 
-				&& len(form[currentProperty.name])
+				&& structKeyExists(form, "#arguments.formUploadDottedPath##currentProperty.name#") 
+				&& len(form["#arguments.formUploadDottedPath##currentProperty.name#"])
 			) {
 				// Wrap in try/catch to add validation error based on fileAcceptMIMEType
 				try {
@@ -415,7 +416,7 @@ component output="false" accessors="true" persistent="false" extends="HibachiObj
 					// Handle s3 upload
 					if(left(uploadDirectory, 5) == 's3://'){
 
-						var uploadData = fileUpload(getVirtualFileSystemPath(), currentProperty.name, currentProperty.hb_fileAcceptMIMEType, 'makeUnique' );
+						var uploadData = fileUpload(getVirtualFileSystemPath(), '#arguments.formUploadDottedPath##currentProperty.name#', currentProperty.hb_fileAcceptMIMEType, 'makeUnique' );
 
 						uploadDirectory = replace(uploadDirectory,'s3://','');
 
@@ -443,7 +444,7 @@ component output="false" accessors="true" persistent="false" extends="HibachiObj
 						}
 
 						// Do the upload
-						var uploadData = fileUpload( uploadDirectory, currentProperty.name, currentProperty.hb_fileAcceptMIMEType, 'makeUnique' );
+						var uploadData = fileUpload( uploadDirectory, '#arguments.formUploadDottedPath##currentProperty.name#', currentProperty.hb_fileAcceptMIMEType, 'makeUnique' );
 
 						// Update the property with the serverFile name
 						_setProperty(currentProperty.name, uploadData.serverFile);

--- a/org/Hibachi/HibachiTransient.cfc
+++ b/org/Hibachi/HibachiTransient.cfc
@@ -449,7 +449,7 @@ component output="false" accessors="true" persistent="false" extends="HibachiObj
 						// Update the property with the serverFile name
 						_setProperty(currentProperty.name, uploadData.serverFile);
 
-						// Call setXXUploadState() method if exists to store the upload status data
+						// Call setXXUploadStatus() method if exists to store the upload status data
 						if (structKeyExists(this, 'set#currentProperty.name#UploadStatus')) {
 							invokeMethod('set#currentProperty.name#UploadStatus', {1=uploadData});
 						}

--- a/org/Hibachi/HibachiTransient.cfc
+++ b/org/Hibachi/HibachiTransient.cfc
@@ -448,6 +448,11 @@ component output="false" accessors="true" persistent="false" extends="HibachiObj
 
 						// Update the property with the serverFile name
 						_setProperty(currentProperty.name, uploadData.serverFile);
+
+						// Call setXXUploadState() method if exists to store the upload status data
+						if (structKeyExists(this, 'set#currentProperty.name#UploadStatus')) {
+							invokeMethod('set#currentProperty.name#UploadStatus', {1=uploadData});
+						}
 					}
 
 				} catch(any e) {


### PR DESCRIPTION
Previously the file upload functionality looked only at form.[propertyName] to use for uploading. But if a file upload property existed as a nested populated subproperty, the file upload functionality can't handle that scenario. The form scope key it looks for does not exist. It needs some sense of context in order to properly map to the proper key in the form scope. Te changes allow more flexibility in handling file uploads.

For example
Item.cfc has a property Project.cfc which has multiple file uploads associated with it like ProjectFile.cfc (with property name="theFileUpload" ... hb_fileUpload="true"). Now populate will successfully upload those files because it will reference form.project.projectFiles[1].theFileUpload instead of assuming it exists as form.theFileUpload

Before creating this I first tried simply creating a new root key in the form scope that pointed to the original file upload key (eg. form.theFileUpload -> form.project.projectFiles[1].theFileUpload) but CF fileUpload would error trying locate file content. There must be more going on under the hood in the CF Engine to map to actual file content.

