### PR TITLE
Fixing weird issue in buildFormCollections with Lucee

### DIFF
--- a/org/Hibachi/HibachiUtilityService.cfc
+++ b/org/Hibachi/HibachiUtilityService.cfc
@@ -1172,6 +1172,9 @@
 			<!--- If the field has a dot or a bracket... --->
 			<cfif hasFormCollectionSyntax(local.thisField)>
 
+				<!--- NOTE: Edge case issue caused by Lucee automatically converting keys with array syntax and inflating new form scope variables to represent arrays (a Lucee hidden gem) --->
+				<cfset local.isLuceeTerminalCollectionFieldFlag = right(local.thisField, 1) eq ']' />
+
 				<!--- Add collection to list if not present. --->
 				<cfset local.tempStruct['formCollectionsList'] = addCollectionNameToCollectionList(local.tempStruct['formCollectionsList'], local.thisField) />
 
@@ -1205,7 +1208,7 @@
 
 						<cfif local.tempIndex eq 0>
 							<cfset local.currentElement[local.tempElement] = arguments.formScope[local.thisField] />
-						<cfelse>
+						<cfelseif not local.isLuceeTerminalCollectionFieldFlag>
 							<cfset local.currentElement[local.tempElement][local.tempIndex] = arguments.formScope[local.thisField] />
 						</cfif>
 


### PR DESCRIPTION
Fixing weird issue in buildFormCollections with Lucee auto-creating various form scope variables for keys with array syntax. It will cause buildFormCollections logic to overwrite and change key names back to array syntax causing populate to not work properly. Unintended behavior depends on the arbitrary order the keys arrange themselves in the form scope.

Compare the difference between CF and Lucee with the same inputs.

[CF11 Form Scope.html.pdf](https://github.com/ten24/slatwall/files/2143366/CF11.Form.Scope.html.pdf)

[Lucee5 Form Scope.html.pdf](https://github.com/ten24/slatwall/files/2143367/Lucee5.Form.Scope.html.pdf)

This shows the structure that buildFormCollections creates as it goes over the form scope. One depicts how the variables get overwritten or added to the wrong places. Other shows after the fix.

[Issue - Lucee Form Scope Example.html.pdf](https://github.com/ten24/slatwall/files/2143368/Issue.-.Lucee.Form.Scope.Example.html.pdf)

[Fixed - Lucee Form Scope Example.html.pdf](https://github.com/ten24/slatwall/files/2143369/Fixed.-.Lucee.Form.Scope.Example.html.pdf)

