### PR TITLE
'getAttributeValue' attribute validity check

### DIFF
--- a/model/entity/Attribute.cfc
+++ b/model/entity/Attribute.cfc
@@ -335,7 +335,10 @@ component displayname="Attribute" entityname="SlatwallAttribute" table="SwAttrib
 	
 	public boolean function isValidString(string stringValue){
 		var attributeCodeLength = len(getAttributeCode());
-		return attributeCodeLength > len(arguments.stringValue) && lcase(right(getAttributeCode(),len(arguments.stringValue)))!=lcase(arguments.stringValue);
+
+		return attributeCodeLength < len(arguments.stringValue)
+		|| (attributeCodeLength >= len(arguments.stringValue)
+		&& lcase(right(getAttributeCode(),len(arguments.stringValue)))!=lcase(arguments.stringValue));
 	}
 	
 	public boolean function isValidAttributeCode(){

--- a/model/entity/HibachiEntity.cfc
+++ b/model/entity/HibachiEntity.cfc
@@ -177,7 +177,7 @@ component output="false" accessors="true" persistent="false" extends="Slatwall.o
 	public any function getAttributeValue(required string attribute, returnEntity=false){
 		
 		//If custom property exists for this attribute, return the property value instead
-		if(len(arguments.attribute) eq 32) {
+		if(isValid("uuid",arguments.attribute)) {
 			//If the id is passed in, need to load the attribute in order to get the attribute code
 			var attributeEntity = getService("attributeService").getAttributeByAttributeID(arguments.attribute);
 			
@@ -203,7 +203,7 @@ component output="false" accessors="true" persistent="false" extends="Slatwall.o
 		var attributeValueEntity = "";
 		
 		// If an ID was passed, and that value exists in the ID struct then use it
-		if(len(arguments.attribute) eq 32 && structKeyExists(getAttributeValuesByAttributeIDStruct(), arguments.attribute) ) {
+		if(isValid("uuid",arguments.attribute) && structKeyExists(getAttributeValuesByAttributeIDStruct(), arguments.attribute) ) {
 			attributeValueEntity = getAttributeValuesByAttributeIDStruct()[arguments.attribute];
 
 		// If some other string was passed check the attributeCode struct for it's existance
@@ -229,7 +229,7 @@ component output="false" accessors="true" persistent="false" extends="Slatwall.o
 			var newAttributeValue = getService("attributeService").newAttributeValue();
 			newAttributeValue.setAttributeValueType( getClassName() );
 			var thisAttribute = getService("attributeService").getAttributeByAttributeCode( arguments.attribute );
-			if(isNull(thisAttribute) && len(arguments.attribute) eq 32) {
+			if(isNull(thisAttribute) && isValid("uuid",arguments.attribute)) {
 				thisAttribute = getService("attributeService").getAttributeByAttributeID( arguments.attribute );
 			}
 			if(!isNull(thisAttribute)) {
@@ -240,7 +240,7 @@ component output="false" accessors="true" persistent="false" extends="Slatwall.o
 		}
 
 		// If the attributeValueEntity wasn't found, then lets just go look at the actual attribute object by ID/CODE for a defaultValue
-		if(len(arguments.attribute) neq 32) {
+		if(!isValid("uuid",arguments.attribute)) {
 			var attributeEntity = getService("attributeService").getAttributeByAttributeCode(arguments.attribute);
 		}
 		if(!isNull(attributeEntity) && !isNull(attributeEntity.getDefaultValue()) && len(attributeEntity.getDefaultValue())) {
@@ -252,7 +252,7 @@ component output="false" accessors="true" persistent="false" extends="Slatwall.o
 	
 	public any function setAttributeValue(required string attribute, required any value, boolean valueHasBeenEncryptedFlag=false){
 		//If custom property exists for this attribute, return the property value instead
-		if(len(arguments.attribute) eq 32) {
+		if(isValid("uuid",arguments.attribute)) {
 			//If the id is passed in, need to load the attribute in order to get the attribute code
 			var attributeEntity = getService("attributeService").getAttributeByAttributeID(arguments.attribute);
 			


### PR DESCRIPTION
Slatwall version: 5.1.011

If a custom attribute with a length of exactly 32 chars is created, SW throws an exception - 'variable [attributeEntity] doesn't exist'.

[hibachiEntity-bug-stacktrace.txt](https://github.com/ten24/slatwall/files/2267496/hibachiEntity-bug-stacktrace.txt)


