### PR TITLE
Prevents hard error during integration reload 

### DIFF
--- a/model/entity/Integration.cfc
+++ b/model/entity/Integration.cfc
@@ -123,7 +123,7 @@ component displayname="Integration" entityname="SlatwallIntegration" table="SwIn
 	}
 	
 	public any function getSettings() {
-		if(!isNull(getInstalledFlag()) && getInstalledFlag()) {
+		if(!isNull(getInstalledFlag()) && getInstalledFlag() && !isNull(getIntegrationCFC())) {
 			return getIntegrationCFC().getSettings();	
 		}
 		return {};


### PR DESCRIPTION
when codebase doesn't have an integration installed but is registered in database. Due to integrationService listIntegration entities do postLoad check for record level permissions and access a setting which indirectly causes integration entity to attempt to instantiate integrationCFC before knowing whether its actually installed.