### PR TITLE
Update OrderItemReport.cfc

### DIFF
--- a/model/report/OrderItemReport.cfc
+++ b/model/report/OrderItemReport.cfc
@@ -158,6 +158,8 @@ Notes:
 				  	SwBrand on SwProduct.brandID = SwBrand.brandID
 				  LEFT JOIN
 				  	SwAddress on SwOrderFulfillment.shippingAddressID = SwAddress.addressID
+				  LEFT JOIN 
+					SwOrder ro ON SwOrder.orderID = ro.referencedOrderID
 				WHERE
 					SwOrder.orderOpenDateTime is not null
 				  AND


### PR DESCRIPTION
Referenced Order join is missing from the base OrderItemReport, causing amounts to not consistently match AppliedTax reports.