### PR TITLE
entity queue and calculated properties performance

### DIFF
--- a/admin/views/entity/settingstabs/globaladvanced.cfm
+++ b/admin/views/entity/settingstabs/globaladvanced.cfm
@@ -78,6 +78,7 @@ Notes:
 		<swa:SlatwallSetting settingName="globalS3Bucket"/>
 		<swa:SlatwallSetting settingName="globalS3AccessKey"/>
 		<swa:SlatwallSetting settingName="globalS3SecretAccessKey"/>
+		<swa:SlatwallSetting settingName="globalEntityQueueDataProcessCount"/>
 	</swa:SlatwallSettingTable>
 </cfoutput>
 

--- a/config/resourceBundles/en.properties
+++ b/config/resourceBundles/en.properties
@@ -2573,6 +2573,7 @@ entity.WorkflowTaskAction.processMethod                                         
 entity.WorkflowTaskAction.updateData                                                                           = Update Data
 entity.WorkflowTaskAction.workflowTaskActionID                                                                 = Workflow Task Action ID
 entity.WorkflowTaskAction_plural                                                                               = Workflow Task Actions
+entity.WorkflowTrigger.collectionpassthrough                                                                   = Passthrough Collection Data
 entity.WorkflowTrigger.nextRunDateTime                                                                         = Next Run Date Time
 entity.WorkflowTrigger.norecordsfound                                                                          = No triggers have been created
 entity.WorkflowTrigger.objectPropertyIdentifier                                                                = Object Property Identifier
@@ -5288,5 +5289,6 @@ setting.SKUGIFTCARDRECIPIENTREQUIRED=Require Sku Gift Card Recipient
 setting.GLOBALDISABLERECORDLEVELPERMISSIONS=Disable Recodord Level Permissions
 setting.GLOBALALLOWTHIRDPARTYSHIPPINGACCOUNT=Allow Third Party Shipping Accounts
 setting.GLOBALURLKEYCATEGORY=URL Key Category
+setting.globalEntityQueueDataProcessCount=Entity Queue Data Process Limit per Request
 
 

--- a/model/entity/EntityQueue.cfc
+++ b/model/entity/EntityQueue.cfc
@@ -58,6 +58,7 @@ component entityname="SlatwallEntityQueue" table="SwEntityQueue" persistent="tru
 	property name="entityQueueData" ormtype="string" length="8000";
 	property name="logHistoryFlag" ormtype="boolean" default="0";
 	property name="mostRecentError" ormtype="string" length="8000";
+	property name="tryCount" ormType="integer" default="0";
 
 	// Related Object Properties (many-to-one)
 	

--- a/model/entity/OrderItem.cfc
+++ b/model/entity/OrderItem.cfc
@@ -121,6 +121,8 @@ component entityname="SlatwallOrderItem" table="SwOrderItem" persistent="true" a
 	property name="quantityUnreceived" persistent="false";
 	property name="registrants" persistent="false";
 	property name="renewalSku" persistent="false";
+	property name="skuPerformCascadeCalculateFlag" persistent="false";
+	property name="stockPerformCascadeCalculateFlag" persistent="false";
 	property name="taxAmount" persistent="false" hb_formatType="currency";
 	property name="taxLiabilityAmount" persistent="false" hb_formatType="currency";
 	property name="itemTotal" persistent="false" hb_formatType="currency";
@@ -553,6 +555,14 @@ component entityname="SlatwallOrderItem" table="SwOrderItem" persistent="true" a
 		}
 
 		return variables.activeRegistrationsSmartList;
+	}
+	
+	public boolean function getSkuPerformCascadeCalculateFlag() {
+		return getOrderStatusCode() != 'ostNotPlaced';
+	}
+	
+	public boolean function getStockPerformCascadeCalculateFlag() {
+		return getOrderStatusCode() != 'ostNotPlaced';
 	}
 
 	public numeric function getTaxAmount() {

--- a/model/entity/WorkflowTrigger.cfc
+++ b/model/entity/WorkflowTrigger.cfc
@@ -50,6 +50,7 @@ component entityname="SlatwallWorkflowTrigger" table="SwWorkflowTrigger" persist
 	property name="startDateTime" ormtype="timestamp";
 	property name="endDateTime" ormtype="timestamp" hb_nullRBKey="define.forever";
 	property name="collectionFetchSize" ormtype="integer";
+	property name="collectionPassthrough" ormType="boolean" hb_formatType="yesno" default="false";
 	property name="timeout" ormtype="integer" default="90"; 
 	
 	// Calculated Properties

--- a/model/service/SettingService.cfc
+++ b/model/service/SettingService.cfc
@@ -274,6 +274,8 @@ component extends="HibachiService" output="false" accessors="true" {
 			globalS3SecretAccessKey = {fieldtype="password", encryptValue=true},
 			globalWhiteListedEmailDomains = {fieldtype="text"},
 			globalTestingEmailDomain = {fieldtype="text"},
+			globalHibachiCacheName= {fieldtype="text",defaultValue="slatwall"},
+			globalEntityQueueDataProcessCount = {fieldType="text", defaultValue=0, validate={dataType="numeric", required=true}},
 			globalQuotePriceFreezeExpiration = {fieldtype="text", defaultValue="90", validate={dataType="numeric", required=true}},
 			
 			// Image

--- a/org/Hibachi/Hibachi.cfc
+++ b/org/Hibachi/Hibachi.cfc
@@ -952,6 +952,25 @@ component extends="framework.one" {
 
 		// Commit audit queue
 		getHibachiScope().getService("hibachiAuditService").commitAudits();
+		
+		//Process request entity queue
+		var entityQueueData = getHibachiScope().getEntityQueueData();
+		var entityQueueDataLength = structCount(entityQueueData);
+		if(entityQueueDataLength > 0){
+			
+			var entityQueueArray = [];
+			var currentIndex = 1;
+			var limit = getHibachiScope().setting('globalEntityQueueDataProcessCount');
+			for(var i in entityQueueData){
+				if(limit > 0 && limit >= currentIndex){
+					break;
+				}
+				arrayAppend(entityQueueArray, entityQueueData[i]);
+				currentIndex++;
+			}
+			getHibachiScope().getService("hibachiEntityQueueService").processEntityQueueArray(entityQueueArray, true);	
+		}
+		
 		getHibachiScope().getProfiler().logProfiler();
 	}
 

--- a/org/Hibachi/HibachiDAO.cfc
+++ b/org/Hibachi/HibachiDAO.cfc
@@ -123,114 +123,18 @@
 	    public void function flushORMSession(boolean runCalculatedPropertiesAgain=false) {
 	    	// Initate the first flush
 	    	ormFlush();
+	    	// flush again to persist any changes done during ORM Event handler
+			ormFlush();	
 
 			// Use once and clear to avoid reprocessing in subsequent method invocation or through an infinite recursive loop.
 			var modifiedEntities = getHibachiScope().getModifiedEntities();
 			getHibachiScope().clearModifiedEntities();
-
-			if(getService('hibachiUtilityService').isInThread()){
-				// Loop over the modifiedEntities to call updateCalculatedProperties
-		    	for(var entity in modifiedEntities){
-		    		if(getService('HibachiService').getEntityHasCalculatedPropertiesByEntityName(entity.getClassName())){
-		    			entity.updateCalculatedProperties(runAgain=arguments.runCalculatedPropertiesAgain);
-		    		}
-		    	}
-	
-		    	// flush again to persist any changes done during ORM Event handler
-				ormFlush();
-				var modifiedEntities = getHibachiScope().getModifiedEntities();
-				if (!isNull(modifiedEntities)){
-					getHibachiScope().clearModifiedEntities();
-			
-					// Loop over the modifiedEntities to call updateCalculatedProperties
-			    	for(var entity in modifiedEntities){
-			    		if(getService('HibachiService').getEntityHasCalculatedPropertiesByEntityName(entity.getClassName())){
-			    			entity.updateCalculatedProperties(runAgain=true);
-			    		}
-			    	}
-			
-				    // flush again to persist any changes done during update calculated properties.
-					ormflush();
-				}
-			}else{
-				var entityDataArray = [];
-				for(var entity in modifiedEntities){
-					if(getService('HibachiService').getEntityHasCalculatedPropertiesByEntityName(entity.getClassName())){
-						var entityData = {
-							entityName=entity.getClassName(),
-							entityID=entity.getPrimaryIDValue()
-						};
-						arrayAppend(entityDataArray,entityData);
-					}
-					
-				}
-				if(arraylen(entityDataArray)){
-					var threadName = "updateCalculatedProperties_#replace(createUUID(),'-','','ALL')#";
-					thread name="#threadName#" entityDataArray="#entityDataArray#" {
-						try{
-							if(getHibachiScope().getApplicationValue("initialized")){
-								//add to the entityQueue
-								for(var entity in attributes.entityDataArray){
-									//always make a new one so we can calculate multiple times
-									getService('HibachiEntityQueueDAO').insertEntityQueue(entity.entityID,entity.entityName,'calculatedProperty');
-								}
-								ormFlush();	
-							
-					    		//get everything in the queue currently
-					    		var entitiesToCalculateCollectionList = getService('HibachiEntityQueueService').getEntityQueueCollectionList();
-					    		entitiesToCalculateCollectionList.setDisplayProperties('entityQueueID,baseObject,baseID');
-					    		entitiesToCalculateCollectionList.addFilter('entityQueueType','calculatedProperty');
-					    		
-					    		var entitiesToCalculateRecords = entitiesToCalculateCollectionList.getRecords();
-					    		
-					    		var successfulEntities = [];
-					    		//process then and save feedback
-						    	for(var entityData in entitiesToCalculateRecords){
-									try{
-										var entityService = getService('hibachiService').getServiceByEntityName(trim(entityData['baseObject']));
-										var threadEntity = entityService.invokeMethod('get#entityData["baseObject"]#',{1=trim(entityData['baseID'])});
-										if(!isNull(threadEntity)){
-											threadEntity.updateCalculatedProperties();
-											ormFlush();
-										}
-										
-										arrayAppend(successfulEntities,trim(entityData['entityQueueID']));
-									}catch(any e){
-										//if failed then log the recent failure
-										ORMExecuteQuery('UPDATE SlatwallEntityQueue SET mostRecentError=:mostRecentError WHERE entityQueueID=:entityQueueID',{entityQueueID=trim(entityData['entityQueueID']),mostRecentError=e.message & ' - ' &e.detail});
-									}
-									
-					    		}
-					    		//clear successful calculations
-					    		if(arraylen(successfulEntities)){
-					    			ORMExecuteQuery(
-						    			"DELETE FROM SlatwallEntityQueue WHERE entityQueueType=:entityQueueType AND entityQueueID IN ( :successfulEntities ) "
-						    			,{successfulEntities=successfulEntities,entityQueueType='calculatedProperty'}
-						    		);
-					    		}
-					    		ormflush();
-					    		//repeat if there are new modified entities
-					    		var modifiedEntities = getHibachiScope().getModifiedEntities();
-								if (!isNull(modifiedEntities)){
-									getHibachiScope().clearModifiedEntities();
-							
-									// Loop over the modifiedEntities to call updateCalculatedProperties
-							    	for(var entity in modifiedEntities){
-							    		if(getService('HibachiService').getEntityHasCalculatedPropertiesByEntityName(entity.getClassName())){
-							    			entity.updateCalculatedProperties(runAgain=true);
-							    		}
-							    	}
-							
-								    // flush again to persist any changes done during update calculated properties.
-									ormflush();
-								}
-							}
-						}catch(any e){
-							getHibachiScope().logHibachi(e.detail ,true);
-						}
-			    	}
-				}
-		    }
+			// Loop over the modifiedEntities to add updateCalculatedProperties to entity queue
+	    	for(var entity in modifiedEntities){
+	    		if(getService('HibachiService').getEntityHasCalculatedPropertiesByEntityName(entity.getClassName())){
+	    			getHibachiScope().addEntityQueueData(entity.getPrimaryIDValue(), entity.getClassName(), 'process#entity.getClassName()#_updateCalculatedProperties');
+	    		}
+	    	}
 	    }
 
 	    public void function clearORMSession() {

--- a/org/Hibachi/HibachiEntityQueueDAO.cfc
+++ b/org/Hibachi/HibachiEntityQueueDAO.cfc
@@ -66,17 +66,41 @@ component extends="HibachiDAO" persistent="false" accessors="true" output="false
 		);
 	}
 	
-	public void function insertEntityQueue(required string entityID, required string entityName, required string entityQueueType){
+	public void function insertEntityQueue(required string baseID, required string baseObject, string processMethod='', string entityQueueID = createHibachiUUID()){
 		var queryService = new query();
-		var sql = "INSERT INTO SwEntityQueue (entityQueueID,entityQueueType,baseObject,baseID,createdDateTime,createdByAccountID,modifiedByAccountID,modifiedDateTime)
-			VALUES ('#createHibachiUUID()#','#arguments.entityQueueType#','#arguments.entityName#','#arguments.entityID#',:createdDateTime,'#getHibachiScope().getAccount().getAccountID()#',
-				'#getHibachiScope().getAccount().getAccountID()#',:modifiedDatetime
-			)
-		";
-		queryService.addParam(name='createdDateTime',value='#now()#',CFSQLTYPE="CF_SQL_TIMESTAMP");
-		queryService.addParam(name='modifiedDateTime',value='#now()#',CFSQLTYPE="CF_SQL_TIMESTAMP");
+		queryService.addParam(name='entityQueueID',value='#arguments.entityQueueID#',CFSQLTYPE="CF_SQL_STRING");
+		queryService.addParam(name='entityQueueType',value='#arguments.entityQueueType#',CFSQLTYPE="CF_SQL_STRING");
+		queryService.addParam(name='baseObject',value='#arguments.baseObject#',CFSQLTYPE="CF_SQL_STRING");
+		queryService.addParam(name='baseID',value='#arguments.baseID#',CFSQLTYPE="CF_SQL_STRING");
+		queryService.addParam(name='processMethod',value='#arguments.processMethod#',CFSQLTYPE="CF_SQL_STRING");
+		queryService.addParam(name='dateTimeNow',value='#now()#',CFSQLTYPE="CF_SQL_TIMESTAMP");
+		queryService.addParam(name='accountID',value='#getHibachiScope().getAccount().getAccountID()#',CFSQLTYPE="CF_SQL_STRING");
+		
+		var sql =	"INSERT INTO 
+						SwEntityQueue (entityQueueID,entityQueueType,baseObject,baseID,processMethod,createdDateTime,createdByAccountID,modifiedByAccountID,modifiedDateTime)
+					VALUES 
+						(:entityQueueID,:entityQueueType,:baseObject,:baseID,:processMethod,:dateTimeNow,:accountID,:accountID,:dateTimeNow)";
+						
 		queryService.execute(sql=sql);
 	}
+	
+	public void function deleteEntityQueues(required string entityQueueIDs){
+		var queryService = new query();
+		queryService.addParam(name='entityQueueID',value='#arguments.entityQueueIDs#',CFSQLTYPE="CF_SQL_STRING", list="true");
+		var sql = "DELETE FROM SwEntityQueue WHERE entityQueueID IN ( :entityQueueID )";
+						
+		queryService.execute(sql=sql);
+	}
+
+	public void function updateModifiedDateTime(required string entityQueueIDs){
+		var queryService = new query();
+		queryService.addParam(name='entityQueueID',value='#arguments.entityQueueIDs#',CFSQLTYPE="CF_SQL_STRING", list="true");
+		queryService.addParam(name='now',value='#now()#',CFSQLTYPE="CF_SQL_DATE", list="true");
+		var sql = "UPDATE SwEntityQueue SET modifiedDateTime = :now, tryCount= ISNULL(tryCount, 0) + 1  WHERE entityQueueID IN ( :entityQueueID )";
+						
+		queryService.execute(sql=sql);
+	}
+
 	
 	public void function addEntityToQueue(required any entity,required entityQueueType){
 		

--- a/org/Hibachi/HibachiEntityQueueService.cfc
+++ b/org/Hibachi/HibachiEntityQueueService.cfc
@@ -1,22 +1,141 @@
 component accessors="true" output="false" extends="HibachiService" {
+	
+	property name="hibachiEntityQueueDAO" type="any";
+	
 
 	public any function getEntityQueueByBaseObjectAndBaseIDAndEntityQueueTypeAndIntegrationAndEntityQueueData(required string baseObject, required string baseID, required string entityQueueType, required any integration, required entityQueueData){
-		return getDao('hibachiEntityQueueDao').getEntityQueueByBaseObjectAndBaseIDAndEntityQueueTypeAndIntegrationAndEntityQueueData(argumentCollection=arguments);
+		return getHibachiEntityQueueDAO().getEntityQueueByBaseObjectAndBaseIDAndEntityQueueTypeAndIntegrationAndEntityQueueData(argumentCollection=arguments);
 	}
 
-	public void function processEntityQueue_processQueue( required any entityQueue, required any processObject ) {
 
-		//call process from Queued Entity
-		var entityService = getServiceByEntityName( entityName=arguments.entityQueue.getBaseObject() );
-		var processContext = arguments.entityQueue.getProcessMethod();
-		var entity = entityService.invokeMethod( "get#arguments.entityQueue.getBaseObject()#", arguments.entityQueue.getBaseID() );
-		var processData = { '1' = arguments.entity };
-
-		if( arguments.entity.hasProcessObject( processContext ) ){
-			processData['2'] = arguments.entity.getProcessObject( processContext );
+	public void function addQueueHistory(required any entityQueue, required boolean success){
+		var entityQueueHistory = this.newEntityQueueHistory();
+		entityQueueHistory.setEntityQueueType(arguments.entityQueue.getEntityQueueType());
+		entityQueueHistory.setBaseObject(arguments.entityQueue.getBaseObject());
+		entityQueueHistory.setBaseID(arguments.entityQueue.getBaseID());
+		entityQueueHistory.setEntityQueueHistoryDateTime(arguments.entityQueue.getEntityQueueDateTime());
+		entityQueueHistory.setSuccessFlag(arguments.success);
+		entityQueueHistory = this.saveEntityQueueHistory(entityQueueHistory);
+	}
+	
+	public any function processEntityQueue_processQueue( required any entityQueue, any processObject ={} ) {
+		
+		if(!entityQueue.getNewFlag()){
+			//Process a single QUEUE item:
+			
+			var entityService = getServiceByEntityName( entityName=arguments.entityQueue.getBaseObject() );
+			var entity = entityService.invokeMethod( "get#arguments.entityQueue.getBaseObject()#", arguments.entityQueue.getBaseID() );
+			var processContext = arguments.entityQueue.getProcessMethod();
+			if(isNull(entity)){
+				deleteEntityQueueItems(arguments.entityQueue.getEntityQueueID());
+				return arguments.entityQueue;
+			}
+			
+			var processContextIndex = '2';
+			var processData = {'1'=entity};
+			
+			if(isJSON(entityQueue.getEntityQueueData())){
+				processData['2'] = deserializeJSON(entityQueue.getEntityQueueData());
+				processContextIndex = '3';
+			}
+	
+			if(len(processContext) && entity.hasProcessObject(processContext)){
+				processData[processContextIndex] = entity.getProcessObject(processContext);
+			}
+			
+			try{
+				entityService.invokeMethod("#arguments.entityQueue.getProcessMethod()#", processData);
+				deleteEntityQueueItems(arguments.entityQueue.getEntityQueueID());
+			}catch(any e){
+				if(!isNull(entityQueue.getLogHistoryFlag()) && entityQueue.getLogHistoryFlag()){
+					addQueueHistory(entityQueue, false);
+				}
+				arguments.entityQueue.setModifiedDateTime(now());
+				this.saveEntityQueue(arguments.entityQueue);
+			}
+		}else if(structKeyExists(arguments, 'processObject') && structKeyExists(arguments.processObject,'collectionData')){
+			//Process a collection of QUEUE
+			processEntityQueueArray(arguments.processObject.collectionData);
+		}else{
+			//Build a queue collection list 
+			var entityQueueCollection = getEntityQueueCollectionList();
+			entityQueueCollection.setDisplayProperties('entityQueueID,baseObject,baseID,entityQueueData,processMethod');
+			entityQueueCollection.setPageRecordsShow(20);
+			entityQueueCollection.addOrderBy('modifiedDateTime|DESC');
+			var entityQueuItems = entityQueueCollection.getPageRecords(formatRecords=false);
+			
+			return this.processEntityQueue_processQueue( this.newEntityQueue(), { 'collectionData' = entityQueuItems } );
 		}
-
-		entityService.invokeMethod( "process#arguments.entityQueue.getBaseObject()#_#arguments.entityQueue.getProcessMethod()#", processData );
+	
+		return entityQueue;
 	}
+	
+	public any function processEntityQueueArray(required array entityQueueArray, useThread = false){
+			
+		if(!arraylen(arguments.entityQueueArray)){
+			return;
+		}
+		
+		if(arguments.useThread == true && !getService('hibachiUtilityService').isInThread()){
+			var threadName = "updateCalculatedProperties_#replace(createUUID(),'-','','ALL')#";
+			thread name="#threadName#" entityQueueArray="#arguments.entityQueueArray#" {
+				processEntityQueueArray(entityQueueArray, false);
+			}
+		}else{
+			var entityQueueIDsToBeDeleted = '';
+			var entityQueueIDsToBeUpdated = '';
+			
+			for(var entityQueue in arguments.entityQueueArray){
+			
+				var entityService = getServiceByEntityName( entityName=entityQueue['baseObject'] );
+				var entity = entityService.invokeMethod( "get#entityQueue['baseObject']#", {1= entityQueue['baseID'] });
+				if(isNull(entity)){
+					entityQueueIDsToBeDeleted = listAppend(entityQueueIDsToBeDeleted, entityQueue['entityQueueID']);
+					continue;
+				}
+				var processContextIndex = '2';
+				var processData = { '1'=entity };
+				
+				if(isJSON(entityQueue['entityQueueData'])){
+					processData['2'] = deserializeJSON(entityQueue['entityQueueData']);
+					processContextIndex = '3';
+				}
+	
+				if(len(entityQueue['processMethod']) && entity.hasProcessObject(entityQueue['processMethod'])){
+					processData[processContextIndex] = entity.getProcessObject(entityQueue['processMethod']);
+				}
+				
+				try{
+					entityService.invokeMethod("#entityQueue['processMethod']#", processData);
+					entityQueueIDsToBeDeleted = listAppend(entityQueueIDsToBeDeleted, entityQueue['entityQueueID']);
+					ormflush();
+				}catch(any e){
+					entityQueueIDsToBeUpdated = listAppend(entityQueueIDsToBeUpdated, entityQueue['entityQueueID']);
+				}
+			}
+			if(listLen(entityQueueIDsToBeDeleted)){
+				deleteEntityQueueItems(entityQueueIDsToBeDeleted);
+			}
+			if(listLen(entityQueueIDsToBeUpdated)){
+				updateModifiedDateTime(entityQueueIDsToBeUpdated);
+			}
+			
+			
+		}
+	}
+	
+	
 
+	public any function insertEntityQueueItem(required string baseID, required string baseObject, string processMethod='', any entityQueueData={}, string entityQueueType = '', string entityQueueID = createHibachiUUID()){
+		getHibachiEntityQueueDAO().insertEntityQueue(argumentCollection=arguments);
+	}
+	
+	public void function deleteEntityQueueItems(required string entityQueueID){
+		getHibachiEntityQueueDAO().deleteEntityQueues(entityQueueID);
+	}
+	
+	public void function updateModifiedDateTime(required string entityQueueID){
+		getHibachiEntityQueueDAO().updateModifiedDateTime(entityQueueID);
+	}
+	
 }

--- a/org/Hibachi/HibachiScope.cfc
+++ b/org/Hibachi/HibachiScope.cfc
@@ -22,6 +22,7 @@ component output="false" accessors="true" extends="HibachiTransient" {
 	property name="isAWSInstance" type="boolean" default="0";
 	property name="entityURLKeyType" type="string";
 	property name="permissionGroupCacheKey" type="string";
+	property name="entityQueueData" type="struct";
 
 	public any function init() {
 		setORMHasErrors( false );
@@ -445,4 +446,51 @@ component output="false" accessors="true" extends="HibachiTransient" {
 	public boolean function authenticateCollectionPropertyIdentifier(required string crudType, required any collection, required string propertyIdentifier){
 		return getHibachiAuthenticationService().authenticateCollectionPropertyIdentifierCrudByAccount( crudType=arguments.crudType, collection=arguments.collection, propertyIdentifier=arguments.propertyIdentifier, account=getAccount() );
 	}
+	
+	
+	public any function addEntityQueueData(required string baseID, required string baseObject, string processMethod='', any entityQueueData={}, string entityQueueType = ''){
+		if(!structKeyExists(variables, "entityQueueData")) {
+			variables.entityQueueData = {};
+		}
+		arguments.entityQueueID = getDAO('HibachiDAO').createHibachiUUID();
+		
+		if(!structKeyExists(variables.entityQueueData, '#arguments.baseObject#_#arguments.baseID#_#arguments.processMethod#')){
+			variables.entityQueueData['#arguments.baseObject#_#arguments.baseID#_#arguments.processMethod#'] = arguments;
+			getService('HibachiEntityQueueService').insertEntityQueueItem(argumentCollection=arguments);
+		}
+	}
+	
+	public struct function getEntityQueueData(){
+		if(!structKeyExists(variables, "entityQueueData")) {
+			variables.entityQueueData = {};
+		}
+		return variables.entityQueueData;
+		
+	}
+	
+	public void function clearEntityQueueData(){
+		var entityQueues = getEntityQueueData();
+		var entityQueueIDsToBeDeleted = '';
+		
+		for(var entityQueue in entityQueues){
+			entityQueueIDsToBeDeleted = listAppend(entityQueueIDsToBeDeleted, entityQueues[entityQueue]['entityQueueID']);
+		}
+		variables.entityQueueData = {};
+		getService('HibachiEntityQueueService').deleteEntityQueueItems(entityQueueIDsToBeDeleted);
+		
+	}
+	
+	public void function deleteEntityQueue(entityQueueID){
+		var entityQueues = getEntityQueueData();
+		
+		for(var entityQueue in entityQueues){
+			if(entityQueues[entityQueue]['entityQueueID'] == arguments.entityQueueID){
+				StructDelete(entityQueues, entityQueue);
+				getService('HibachiEntityQueueService').deleteEntityQueueItems(arguments.entityQueueID);
+				break;
+			}
+		}
+		
+	}
+	
 }

--- a/org/Hibachi/HibachiService.cfc
+++ b/org/Hibachi/HibachiService.cfc
@@ -432,7 +432,11 @@
 			} else if ( lCaseMissingMethodName.startsWith( 'export' ) ) {
 				return onMissingExportMethod( missingMethodName, missingMethodArguments );
 			} else if ( lCaseMissingMethodName.startsWith( 'process' ) ) {
-				return onMissingProcessMethod( missingMethodName, missingMethodArguments );
+				if(right(lCaseMissingMethodName,27) == "_updateCalculatedProperties") {
+					return onMissingUpdateCalculatedProperties(missingMethodName, missingMethodArguments);
+				}else{
+					return onMissingProcessMethod( missingMethodName, missingMethodArguments );
+				}
 			}
 
 			throw('You have called a method #arguments.missingMethodName#() which does not exists in the #getClassName()# service.');
@@ -761,6 +765,14 @@
 			
 			export(data=exportQry);
 		}
+		
+		
+		private any function onMissingUpdateCalculatedProperties( required string missingMethodName, required struct missingMethodArguments ){
+			var entity = missingMethodArguments[1];
+			entity.updateCalculatedProperties();
+			return entity;
+		}
+		
 		
 		// @hint returns the correct service on a given entityName.  This is very useful for creating abstract code
 		public boolean function getEntityNameIsValidFlag( required string entityName ) {

--- a/org/Hibachi/client/src/workflow/components/workflowtriggers.html
+++ b/org/Hibachi/client/src/workflow/components/workflowtriggers.html
@@ -154,6 +154,7 @@
                                                     data-editable="true"
                                                     data-editing="true"
                                                     ></sw-property-display>
+
                                             <sw-property-display
                                                     data-object="workflowTriggers.selectedTrigger"
                                                     data-property-identifier="saveTriggerHistoryFlag"
@@ -263,6 +264,12 @@
                                         <sw-property-display
                                                 data-object="workflowTriggers.selectedTrigger"
                                                 data-property-identifier="timeout"
+                                                data-editing="true"
+                                                data-is-dirty="true"
+                                        ></sw-property-display>
+                                         <sw-property-display
+                                                data-object="workflowTriggers.selectedTrigger"
+                                                data-property-identifier="collectionPassthrough"
                                                 data-editing="true"
                                                 data-is-dirty="true"
                                         ></sw-property-display>


### PR DESCRIPTION
Please review and run locally to test to verify Workflows functionality works as expected. 

I assume a workflow must manually be configured first to process queue if the global setting 'globalEntityQueueDataProcessCount' = 0 otherwise nothing is going to execute for the entity queue processing.

Some of the merging conflicts with the WorkflowService.cfc and HibachiEntityQueueDAO.cfc were a bit less straightforward.

But this should be everything.