### PR TITLE
Update order amounts with taxes

### DIFF
--- a/model/service/OrderService.cfc
+++ b/model/service/OrderService.cfc
@@ -2134,9 +2134,9 @@ component extends="HibachiService" persistent="false" accessors="true" output="f
 			getPromotionService().updateOrderAmountsWithPromotions( arguments.order );
 
 			// Re-Calculate tax now that the new promotions and price groups have been applied
-		    if(arguments.order.getPaymentAmountDue() > 0){
+		    	if(arguments.order.getPaymentAmountDue() != 0){
 				getTaxService().updateOrderAmountsWithTaxes( arguments.order );
-		    }
+		    	}
 
 			//update the calculated properties
 			getHibachiScope().addModifiedEntity(arguments.order);


### PR DESCRIPTION
Fixes an issue where taxes don't calculate for return items on a sales order because the order was paid for previous to the return item being added. The current check only recalculates if the payment due is great than 0, but in the case where you are adding a return sku on  paid order, the payment amount due will be -negative. Updating the check to recalculate whenever the payment is not zero, fixes because if the custom is owed or the customer owes, taxes are applied. But when its balanced (0), it does not recalculate.