### PR TITLE
Update productListingUrlFilterBadges.cfm

### DIFF
--- a/integrationServices/slatwallcms/skeletonsite/templates/inc/productListingUrlFilterBadges.cfm
+++ b/integrationServices/slatwallcms/skeletonsite/templates/inc/productListingUrlFilterBadges.cfm
@@ -4,6 +4,10 @@
   <!--- for every property in the url struct...--->
   <cfset local.counter = 0 />
   <cfloop collection="#url#" item="local.queryParam">
+  
+    	<cfif isStruct(url[local.queryParam]) >
+  		<cfcontinue>
+  	</cfif>
 
   	<!--- We don't want property names that start with p:, for pagination, among other stuff. Let's
   	define only the ones we want --->


### PR DESCRIPTION
lucee groups query params that have dots in them in structs. Let's skip that